### PR TITLE
ci: Add Codecov reports for unit tests too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,10 +103,10 @@ jobs:
             python-dotenv
 
       - name: Run unit tests
-        run: pytest -m "not integration"
+        run: pytest -m "not integration" --cov=paradedb
 
       - name: Run integration tests
-        run: pytest -m integration --cov=paradedb --cov-report=xml
+        run: pytest -m integration --cov=paradedb --cov-append --cov-report=xml
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #23 

## What

Uploads coverage report for unit tests to Codecov as well as the integration tests.

## Why

## How

## Tests
