### PR TITLE
fix: Update Python and Django version requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.2.0"
 description = "ParadeDB integration for Django"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 authors = [
     { name = "ParadeDB", email = "support@paradedb.com" },
 ]
@@ -29,17 +29,21 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Web Environment",
     "Framework :: Django",
+    "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Database",
     "Topic :: Internet :: WWW/HTTP",
 ]
 dependencies = [
-    "Django>=6.0",
+    "Django>=5.2",
 ]
 
 [project.optional-dependencies]
@@ -64,7 +68,7 @@ Issues = "https://github.com/paradedb/django-paradedb/issues"
 packages = ["src/paradedb"]
 
 [tool.ruff]
-target-version = "py313"
+target-version = "py310"
 line-length = 88
 src = ["src", "tests"]
 
@@ -91,7 +95,7 @@ ignore = [
 known-first-party = ["paradedb"]
 
 [tool.mypy]
-python_version = "3.13"
+python_version = "3.10"
 strict = true
 plugins = ["mypy_django_plugin.main"]
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Latest release 0.2.0 still does not permit installation for the python/django versions tested in the CI matrix.

BTW, you could probably also include Django 4.2 LTS, but it's just the dev dependencies (namely `django-stubs` I think) that needs Django 5.2

## Why

## How

## Tests
