### PR TITLE
chore: Remove unused dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "prek>=0.1.0",
     "ruff>=0.8",
     "mypy>=1.13",
     "django-stubs>=5.1",
@@ -58,7 +57,6 @@ dev = [
     "pytest-django>=4.9",
     "pytest-cov>=6.0",
     "psycopg[binary]>=3.1",
-    "psycopg2-binary>=2.9",
 ]
 [project.urls]
 Homepage = "https://github.com/paradedb/django-paradedb"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -8,9 +8,9 @@ import pytest
 from django.db import connection
 
 try:
-    import psycopg2  # noqa: F401
+    import psycopg  # noqa: F401
 except ImportError as exc:
-    raise RuntimeError("psycopg2 is required to run integration tests") from exc
+    raise RuntimeError("psycopg is required to run integration tests") from exc
 
 
 def _require_postgres() -> None:


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Remove `prek` and `psycopg2-binary` from dev dependencies.

## Why

`prek` is a CLI tool for running pre-commit hooks — it's never imported in Python and developers who want it can install it independently. `psycopg2-binary` is redundant since `psycopg[binary]` (psycopg3) is already listed and is what Django's PostgreSQL backend uses.

## How

- Removed `prek>=0.1.0` and `psycopg2-binary>=2.9` from `[project.optional-dependencies] dev`
- Updated the defensive driver import check in `tests/integration/conftest.py` from `psycopg2` to `psycopg`

## Tests

Existing unit and integration tests are unchanged.