### PR TITLE
fix: pass concurrent kwargs in migrations + partial indexes

### DIFF
--- a/src/paradedb/indexes.py
+++ b/src/paradedb/indexes.py
@@ -100,10 +100,11 @@ class BM25Index(models.Index):
         fields: dict[str, dict[str, Any]],
         key_field: str,
         name: str,
+        condition: models.Q | None = None,
     ) -> None:
         self.fields_config = fields
         self.key_field = key_field
-        super().__init__(name=name, fields=list(fields.keys()))
+        super().__init__(name=name, fields=list(fields.keys()), condition=condition)
 
     def deconstruct(self) -> tuple[str, Any, dict[str, Any]]:
         path, args, kwargs = super().deconstruct()
@@ -136,6 +137,11 @@ class BM25Index(models.Index):
             ")\n"
             "WITH (key_field=%(key_field)s)"
         )
+
+        condition_sql = self._get_condition_sql(model, schema_editor)  # type: ignore[attr-defined]
+        if condition_sql:
+            template += f"\nWHERE {condition_sql}"
+
         return Statement(
             template,
             name=index_name,

--- a/tests/integration/test_migrations_integration.py
+++ b/tests/integration/test_migrations_integration.py
@@ -9,6 +9,7 @@ from django.contrib.postgres.operations import (
 )
 from django.db import connection, migrations, models
 from django.db.migrations.state import ProjectState
+from django.db.models import Q
 
 from paradedb.indexes import BM25Index
 
@@ -506,3 +507,81 @@ def test_remove_index_concurrently() -> None:
     finally:
         _drop_table_if_exists(table_name)
         connection.commit()
+
+
+@pytest.mark.django_db(transaction=True)
+def test_add_partial_index() -> None:
+    """BM25Index with condition creates a partial index with a WHERE clause."""
+    app_label = "migtests"
+    table_name = "migtests_partial"
+    index_name = "migtests_partial_bm25_idx"
+
+    _drop_table_if_exists(table_name)
+    connection.commit()
+
+    bm25_index = BM25Index(
+        fields={
+            "id": {},
+            "title": {"tokenizer": "unicode_words"},
+        },
+        key_field="id",
+        name=index_name,
+        condition=Q(is_active=True),
+    )
+
+    create_model = migrations.CreateModel(
+        name="PartialItem",
+        fields=[
+            ("id", models.AutoField(primary_key=True)),
+            ("title", models.TextField()),
+            ("is_active", models.BooleanField(default=True)),
+        ],
+        options={
+            "db_table": table_name,
+            "indexes": [bm25_index],
+        },
+    )
+
+    from_state = ProjectState()
+    to_state = from_state.clone()
+    create_model.state_forwards(app_label, to_state)
+
+    forward_applied = False
+    with connection.schema_editor(atomic=True) as editor:
+        create_model.database_forwards(app_label, editor, from_state, to_state)
+        forward_applied = True
+
+    try:
+        assert _table_exists(table_name)
+        index_def = _fetch_index_definition(table_name, index_name)
+        assert index_def is not None, "Index was not created"
+        assert "USING bm25" in index_def
+        assert "WHERE" in index_def
+
+        # Insert test data and verify the index is functional
+        quoted_table = connection.ops.quote_name(table_name)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"INSERT INTO {quoted_table} (title, is_active) VALUES "
+                f"('test document', true), ('inactive doc', false), "
+                f"('another test', true);"
+            )
+        connection.commit()
+
+        # Verify the partial index is queryable
+        with connection.cursor() as cursor:
+            cursor.execute(
+                f"SELECT COUNT(*) FROM {quoted_table} WHERE title &&& 'test';"
+            )
+            (count,) = cursor.fetchone()
+        # Only active rows are indexed; 'test document' and 'another test'
+        assert count == 2
+
+    finally:
+        if forward_applied and _table_exists(table_name):
+            with connection.schema_editor(atomic=True) as editor:
+                create_model.database_backwards(app_label, editor, to_state, from_state)
+        else:
+            _drop_table_if_exists(table_name)
+            connection.commit()
+        assert not _table_exists(table_name)

--- a/tests/test_sql_generation.py
+++ b/tests/test_sql_generation.py
@@ -1296,6 +1296,50 @@ class TestBM25Index:
         assert sql.startswith('CREATE INDEX "product_search_idx"')
         assert "CONCURRENTLY" not in sql
 
+    def test_create_sql_with_condition(self) -> None:
+        """create_sql with condition appends a WHERE clause."""
+        index = BM25Index(
+            fields={"id": {}, "description": {"tokenizer": "simple"}},
+            key_field="id",
+            name="product_search_idx",
+            condition=Q(description__isnull=False),
+        )
+        schema_editor = DummySchemaEditor()
+        # Mock _get_condition_sql to avoid needing a real DB connection
+        index._get_condition_sql = Mock(return_value='"description" IS NOT NULL')
+        sql = str(index.create_sql(model=Product, schema_editor=schema_editor))
+        assert sql.endswith('WHERE "description" IS NOT NULL')
+        assert "USING bm25" in sql
+
+    def test_create_sql_with_condition_and_concurrently(self) -> None:
+        """create_sql with both condition and concurrently emits both."""
+        index = BM25Index(
+            fields={"id": {}, "description": {"tokenizer": "simple"}},
+            key_field="id",
+            name="product_search_idx",
+            condition=Q(description__isnull=False),
+        )
+        schema_editor = DummySchemaEditor()
+        index._get_condition_sql = Mock(return_value='"description" IS NOT NULL')
+        sql = str(
+            index.create_sql(
+                model=Product, schema_editor=schema_editor, concurrently=True
+            )
+        )
+        assert sql.startswith('CREATE INDEX CONCURRENTLY "product_search_idx"')
+        assert sql.endswith('WHERE "description" IS NOT NULL')
+
+    def test_create_sql_without_condition_no_where(self) -> None:
+        """create_sql without condition does not append WHERE clause."""
+        index = BM25Index(
+            fields={"id": {}, "description": {"tokenizer": "simple"}},
+            key_field="id",
+            name="product_search_idx",
+        )
+        schema_editor = DummySchemaEditor()
+        sql = str(index.create_sql(model=Product, schema_editor=schema_editor))
+        assert "WHERE" not in sql
+
 
 class TestMoreLikeThis:
     """Test MoreLikeThis SQL generation."""


### PR DESCRIPTION
## Summary
- `BM25Index.create_sql()` was silently ignoring `**kwargs`, which meant `concurrently=True` passed by Django's `AddIndexConcurrently` was dropped — the index was always created with plain `CREATE INDEX`
- Now respects the `concurrently` kwarg to emit `CREATE INDEX CONCURRENTLY` when used with `AddIndexConcurrently` / `RemoveIndexConcurrently`
- Adds `condition` parameter support for partial BM25 indexes — pass a Django `Q` object to generate a `WHERE` clause on `CREATE INDEX`

## Usage

### Concurrent index creation

Django's `AddIndexConcurrently` lets you create BM25 indexes without locking the table for writes — critical for production deployments on large tables.

#### Step 1: Define your model with the index

```python
from django.db import models
from paradedb.indexes import BM25Index
from paradedb.manager import ParadeDBManager

class Article(models.Model):
    title = models.TextField()
    body = models.TextField()

    objects = ParadeDBManager()

    class Meta:
        indexes = [
            BM25Index(
                fields={
                    "id": {},
                    "title": {"tokenizer": "unicode_words"},
                    "body": {"tokenizer": "unicode_words"},
                },
                key_field="id",
                name="article_bm25_idx",
            ),
        ]
```

#### Step 2: Generate the migration

```bash
python manage.py makemigrations
```

This will auto-generate a migration with `AddIndex`. You need to manually edit it.

#### Step 3: Edit the migration to use `AddIndexConcurrently`

```python
from django.contrib.postgres.operations import AddIndexConcurrently
from django.db import migrations
from paradedb.indexes import BM25Index


class Migration(migrations.Migration):
    atomic = False  # Required — CONCURRENTLY cannot run inside a transaction

    dependencies = [("myapp", "0001_initial")]

    operations = [
        AddIndexConcurrently(
            model_name="article",
            index=BM25Index(
                fields={
                    "id": {},
                    "title": {"tokenizer": "unicode_words"},
                    "body": {"tokenizer": "unicode_words"},
                },
                key_field="id",
                name="article_bm25_idx",
            ),
        ),
    ]
```

Key points:
- **`atomic = False`** is mandatory on the `Migration` class — PostgreSQL does not allow `CONCURRENTLY` inside a transaction
- `RemoveIndexConcurrently` works the same way for dropping indexes without blocking writes
- `makemigrations` always generates `AddIndex` — the swap to `AddIndexConcurrently` is a manual one-line edit

### Partial indexes

Pass a `condition` (Django `Q` object) to only index rows matching the condition:

```python
from django.db.models import Q
from paradedb.indexes import BM25Index

BM25Index(
    fields={
        "id": {},
        "title": {"tokenizer": "unicode_words"},
    },
    key_field="id",
    name="active_articles_bm25_idx",
    condition=Q(is_active=True),
)
```

This generates `CREATE INDEX ... USING bm25 (...) WITH (key_field='id') WHERE "is_active"`, reducing index size and improving performance when you only need to search a subset of rows.

## Test plan
- [x] Unit tests: `test_create_sql_concurrently` and `test_create_sql_without_concurrently` verify concurrent SQL generation
- [x] Unit tests: `test_create_sql_with_condition`, `test_create_sql_with_condition_and_concurrently`, `test_create_sql_without_condition_no_where` verify partial index SQL generation
- [x] Integration tests: `test_add_index_concurrently` and `test_remove_index_concurrently` verify concurrent ops end-to-end
- [x] Integration test: `test_add_partial_index` verifies partial index creation and querying with a real ParadeDB instance