### PR TITLE
feat: re-export full public API from top-level package

### DIFF
--- a/src/paradedb/__init__.py
+++ b/src/paradedb/__init__.py
@@ -1,3 +1,59 @@
 """ParadeDB integration for Django ORM."""
 
 __version__ = "0.3.0"
+
+from paradedb.functions import (
+    Agg,
+    Score,
+    Snippet,
+    SnippetPositions,
+    Snippets,
+    paradedb_index_segments,
+    paradedb_indexes,
+    paradedb_verify_all_indexes,
+    paradedb_verify_index,
+)
+from paradedb.indexes import BM25Index
+from paradedb.search import (
+    All,
+    Match,
+    MoreLikeThis,
+    ParadeDB,
+    Parse,
+    Phrase,
+    PhrasePrefix,
+    Proximity,
+    ProximityArray,
+    ProximityRegex,
+    RangeTerm,
+    Regex,
+    RegexPhrase,
+    Term,
+)
+
+__all__ = [
+    "Agg",
+    "All",
+    "BM25Index",
+    "Match",
+    "MoreLikeThis",
+    "ParadeDB",
+    "Parse",
+    "Phrase",
+    "PhrasePrefix",
+    "Proximity",
+    "ProximityArray",
+    "ProximityRegex",
+    "RangeTerm",
+    "Regex",
+    "RegexPhrase",
+    "Score",
+    "Snippet",
+    "SnippetPositions",
+    "Snippets",
+    "Term",
+    "paradedb_index_segments",
+    "paradedb_indexes",
+    "paradedb_verify_all_indexes",
+    "paradedb_verify_index",
+]


### PR DESCRIPTION
# Ticket(s) Closed

All Django snippets now use flat imports from the
  top-level paradedb package:


  # Before
  from paradedb.search import Match, ParadeDB
  from paradedb.functions import Score

  # After
  from paradedb import Match, ParadeDB, Score
## What

## Why

## How

## Tests
