### PR TITLE
chore: Fix critical packaging and SQL interpolation safety issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ Issues = "https://github.com/paradedb/django-paradedb/issues"
 [tool.hatch.build.targets.wheel]
 packages = ["src/paradedb"]
 
+[tool.hatch.build.targets.wheel.force-include]
+"api.json" = "paradedb/api.json"
+
 [tool.ruff]
 target-version = "py310"
 line-length = 88

--- a/src/paradedb/api.py
+++ b/src/paradedb/api.py
@@ -1,6 +1,6 @@
-"""Load paradedb SQL API constants from api.json at the repo root.
+"""Load ParadeDB SQL API constants from api.json.
 
-To add or modify a symbol, edit api.json only.  Every key in every section
+To add or modify a symbol, edit api.json only. Every key in every section
 (operators/functions/types) is exposed as a module-level name::
 
     from paradedb.api import FN_ALL, OP_SEARCH, PDB_TYPE_BOOST
@@ -9,6 +9,21 @@ To add or modify a symbol, edit api.json only.  Every key in every section
 import json
 from pathlib import Path
 
-_api = json.loads((Path(__file__).parent.parent.parent / "api.json").read_text())
+
+def _load_api() -> dict[str, dict[str, str]]:
+    # In installed wheels, api.json is bundled into the package directory.
+    packaged_api = Path(__file__).with_name("api.json")
+    if packaged_api.is_file():
+        return json.loads(packaged_api.read_text(encoding="utf-8"))
+
+    # In editable/source checkouts, fall back to the repository-root file.
+    source_api = Path(__file__).resolve().parents[2] / "api.json"
+    if source_api.is_file():
+        return json.loads(source_api.read_text(encoding="utf-8"))
+
+    raise FileNotFoundError("Could not locate api.json for paradedb.api.")
+
+
+_api = _load_api()
 for _section in _api.values():
     globals().update(_section)

--- a/src/paradedb/functions.py
+++ b/src/paradedb/functions.py
@@ -29,6 +29,15 @@ def _quote_term(value: str) -> str:
     return f"'{escaped}'"
 
 
+def _validate_non_negative_int(name: str, value: int | None) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer.")
+    if value < 0:
+        raise ValueError(f"{name} must be zero or positive.")
+
+
 class Score(Func):
     """BM25 score annotation."""
 
@@ -54,6 +63,7 @@ class Snippet(Func):
         stop_sel: str | None = None,
         max_num_chars: int | None = None,
     ) -> None:
+        _validate_non_negative_int("max_num_chars", max_num_chars)
         self._formatting = (start_sel, stop_sel, max_num_chars)
         super().__init__(F(field))
 
@@ -109,6 +119,9 @@ class Snippets(Func):
             raise ValueError(
                 f"sort_by must be one of {self._VALID_SORT_BY!r}, got {sort_by!r}"
             )
+        _validate_non_negative_int("max_num_chars", max_num_chars)
+        _validate_non_negative_int("limit", limit)
+        _validate_non_negative_int("offset", offset)
         self._start_tag = start_tag
         self._end_tag = end_tag
         self._max_num_chars = max_num_chars

--- a/src/paradedb/search.py
+++ b/src/paradedb/search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -1178,11 +1179,24 @@ class ParadeDB:
         return f"{ParadeDB._quote_term(literal)}::{safe_range_type}"
 
     @staticmethod
+    def _render_scoring_number(value: float | None, *, name: str) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise TypeError(f"{name} must be an int or float.")
+        numeric = float(value)
+        if not math.isfinite(numeric):
+            raise ValueError(f"{name} must be finite.")
+        return str(value)
+
+    @staticmethod
     def _append_scoring(sql: str, *, boost: float | None, const: float | None) -> str:
-        if boost is not None:
-            sql = f"{sql}::{PDB_TYPE_BOOST}({boost})"
-        if const is not None:
-            sql = f"{sql}::{PDB_TYPE_CONST}({const})"
+        boost_sql = ParadeDB._render_scoring_number(boost, name="boost")
+        if boost_sql is not None:
+            sql = f"{sql}::{PDB_TYPE_BOOST}({boost_sql})"
+        const_sql = ParadeDB._render_scoring_number(const, name="const")
+        if const_sql is not None:
+            sql = f"{sql}::{PDB_TYPE_CONST}({const_sql})"
         return sql
 
     @staticmethod

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -445,6 +445,18 @@ class TestSnippetEdgeCases:
         sql = str(queryset.query)
         assert "50" in sql
 
+    def test_snippet_max_num_chars_must_be_integer(self) -> None:
+        with pytest.raises(TypeError, match="max_num_chars must be an integer"):
+            Snippet("description", max_num_chars="50")  # type: ignore[arg-type]
+
+    def test_snippets_limit_must_be_integer(self) -> None:
+        with pytest.raises(TypeError, match="limit must be an integer"):
+            Snippets("description", limit="1")  # type: ignore[arg-type]
+
+    def test_snippets_offset_must_be_integer(self) -> None:
+        with pytest.raises(TypeError, match="offset must be an integer"):
+            Snippets("description", offset="1")  # type: ignore[arg-type]
+
 
 class TestBM25IndexEdgeCases:
     """Test BM25Index edge cases."""
@@ -887,6 +899,24 @@ class TestNewQueryTypeValidation:
         queryset = Product.objects.filter(description=ParadeDB(TermSet("a", "b")))
         sql = str(queryset.query)
         assert "pdb.term_set" in sql
+
+
+class TestScoringValidation:
+    def test_boost_rejects_non_numeric_input(self) -> None:
+        queryset = Product.objects.filter(
+            description=ParadeDB(
+                Match("shoes", operator="AND", boost="1.0)::pdb.const(10")  # type: ignore[arg-type]
+            )
+        )
+        with pytest.raises(TypeError, match="boost must be an int or float"):
+            _ = str(queryset.query)
+
+    def test_const_rejects_non_finite_input(self) -> None:
+        queryset = Product.objects.filter(
+            description=ParadeDB(Match("shoes", operator="AND", const=float("inf")))
+        )
+        with pytest.raises(ValueError, match="const must be finite"):
+            _ = str(queryset.query)
 
 
 class TestSnippetsValidation:


### PR DESCRIPTION
## Summary
- Load api.json from packaged location when installed, with source-tree fallback for local development.
- Include root api.json in wheel builds so paradedb.api works after installation.
- Harden SQL rendering by validating scoring numeric inputs (boost/const) are finite numbers.
- Validate snippet numeric options (max_num_chars, limit, offset) as non-negative integers.
- Add regression tests covering these validation paths.

## Verification
- python3 -m compileall src tests
- Unable to run pytest in this environment because pytest is not installed.