### PR TITLE
feat: changes for making docs ready

### DIFF
--- a/scripts/run_paradedb.sh
+++ b/scripts/run_paradedb.sh
@@ -8,7 +8,7 @@ else
   RUNNING=0
 fi
 
-IMAGE="${PARADEDB_IMAGE:-paradedb/paradedb:0.21.8-pg18}"
+IMAGE="${PARADEDB_IMAGE:-paradedb/paradedb:0.21.10-pg18}"
 CONTAINER_NAME="${PARADEDB_CONTAINER_NAME:-paradedb-integration}"
 
 # Allow overriding connection details via env vars

--- a/src/paradedb/search.py
+++ b/src/paradedb/search.py
@@ -508,6 +508,19 @@ class Match:
             raise TypeError("Match tokenizer must be a string.")
 
         _validate_fuzzy_distance(distance)
+        fuzzy_enabled = _is_fuzzy_enabled(
+            distance=distance,
+            prefix=prefix,
+            transposition_cost_one=transposition_cost_one,
+        )
+        if tokenizer is not None and fuzzy_enabled:
+            raise ValueError("Match tokenizer cannot be combined with fuzzy options.")
+        if (
+            len(terms) > 1
+            and fuzzy_enabled
+            and (boost is not None or const is not None)
+        ):
+            raise ValueError("Multi-term fuzzy Match does not support boost or const.")
 
         object.__setattr__(self, "terms", tuple(terms))
         object.__setattr__(self, "operator", operator)
@@ -1008,6 +1021,27 @@ class ParadeDB:
                 rendered = f"{rendered}::pdb.query"
             scored = self._append_scoring(
                 rendered, boost=self._boost, const=self._const
+            )
+            return f"{lhs_sql} {operator} {scored}", []
+
+        # Multi-term with fuzzy: pdb.fuzzy[] (per-element cast) has no matching operator.
+        # Cast the whole ARRAY: ARRAY['term1', 'term2']::pdb.fuzzy(N) is valid.
+        # Use bare quoted terms (not literals, which already have per-element fuzzy applied).
+        if all(isinstance(t, str) for t in terms) and _is_fuzzy_enabled(
+            distance=self._distance,
+            prefix=self._prefix,
+            transposition_cost_one=self._transposition_cost_one,
+        ):
+            bare = [self._quote_term(t) for t in terms if isinstance(t, str)]
+            array_sql = f"ARRAY[{', '.join(bare)}]"
+            array_sql = self._append_fuzzy(
+                array_sql,
+                distance=self._distance,
+                prefix=self._prefix,
+                transposition_cost_one=self._transposition_cost_one,
+            )
+            scored = self._append_scoring(
+                array_sql, boost=self._boost, const=self._const
             )
             return f"{lhs_sql} {operator} {scored}", []
 

--- a/tests/integration/test_aggregations.py
+++ b/tests/integration/test_aggregations.py
@@ -11,10 +11,10 @@ import json
 
 import pytest
 from django.db.models import Window
-from tests.models import Product
+from tests.models import MockItem, Product
 
 from paradedb.functions import Agg
-from paradedb.search import Match, ParadeDB
+from paradedb.search import All, Match, ParadeDB, Term
 
 pytestmark = [
     pytest.mark.integration,
@@ -334,6 +334,70 @@ class TestAggregationEdgeCases:
         agg_value = json.loads(row[0])
         # Percentiles return values as key-value pairs
         assert "values" in agg_value or isinstance(agg_value, dict)
+
+
+def _agg_dict(value: str | dict) -> dict:  # type: ignore[type-arg]
+    """Normalize an Agg result — psycopg3 returns JSONB as dict, psycopg2 as str."""
+    return value if isinstance(value, dict) else json.loads(value)  # type: ignore[return-value]
+
+
+class TestDjangoOrmAggExecution:
+    """Test Agg Django ORM annotation executes against real DB (docs/aggregates/overview.mdx)."""
+
+    def test_agg_single_value_count(self) -> None:
+        """filter(Term).aggregate(agg=Agg(...)) — docs snippet 1."""
+        result = MockItem.objects.filter(
+            category=ParadeDB(Term("electronics"))
+        ).aggregate(agg=Agg('{"value_count": {"field": "id"}}'))
+        assert isinstance(result, dict)
+        assert "agg" in result
+        assert _agg_dict(result["agg"])["value"] > 0
+
+    def test_agg_grouped_by_rating(self) -> None:
+        """filter(Term).values('rating').annotate(agg=Agg(...)).order_by()[:5] — docs snippet 2."""
+        rows = list(
+            MockItem.objects.filter(category=ParadeDB(Term("electronics")))
+            .values("rating")
+            .annotate(agg=Agg('{"value_count": {"field": "id"}}'))
+            .order_by("rating")[:5]
+        )
+        assert len(rows) > 0
+        for row in rows:
+            assert "rating" in row
+            assert "agg" in row
+            assert _agg_dict(row["agg"])["value"] > 0
+
+    def test_agg_multiple_aggregations(self) -> None:
+        """filter(Term).aggregate(avg_rating=Agg(...), count=Agg(...)) — docs snippet 3."""
+        result = MockItem.objects.filter(
+            category=ParadeDB(Term("electronics"))
+        ).aggregate(
+            avg_rating=Agg('{"avg": {"field": "rating"}}'),
+            count=Agg('{"value_count": {"field": "id"}}'),
+        )
+        assert isinstance(result, dict)
+        assert "avg_rating" in result
+        assert "count" in result
+        assert _agg_dict(result["avg_rating"])["value"] > 0
+        assert _agg_dict(result["count"])["value"] > 0
+
+    def test_agg_with_all_query(self) -> None:
+        """filter(All()).aggregate(...) — docs snippet 4 (All() matches every document)."""
+        result = MockItem.objects.filter(id=ParadeDB(All())).aggregate(
+            agg=Agg('{"value_count": {"field": "id"}}')
+        )
+        assert isinstance(result, dict)
+        assert "agg" in result
+        assert _agg_dict(result["agg"])["value"] > 0
+
+    def test_agg_terms_on_json_subfield(self) -> None:
+        """Agg terms on indexed JSON subfield via ORM aggregate."""
+        result = MockItem.objects.filter(id=ParadeDB(All())).aggregate(
+            agg=Agg('{"terms": {"field": "metadata.color"}}')
+        )
+        assert isinstance(result, dict)
+        assert "agg" in result
+        assert "buckets" in _agg_dict(result["agg"])
 
 
 class TestJSONFieldAggregations:

--- a/tests/integration/test_django_orm_integration.py
+++ b/tests/integration/test_django_orm_integration.py
@@ -9,11 +9,11 @@ from __future__ import annotations
 
 import pytest
 from django.db.models import F, Q, Window
-from django.db.models.functions import RowNumber
+from django.db.models.functions import Lower, RowNumber
 from tests.models import MockItem
 
 from paradedb.functions import Score
-from paradedb.search import Match, ParadeDB, Phrase
+from paradedb.search import Match, ParadeDB, Phrase, Regex, Term
 
 pytestmark = [
     pytest.mark.integration,
@@ -389,3 +389,105 @@ class TestPhraseSearchIntegration:
         )
         for item in queryset:
             assert item.in_stock is True
+
+
+class TestTopNOrdering:
+    """Top N ordering patterns from docs/sorting/topn.mdx."""
+
+    def test_topn_tiebreaker_ordering(self) -> None:
+        """order_by('rating', 'id') tiebreaker — docs/sorting/topn.mdx snippet 2."""
+        rows = list(
+            MockItem.objects.filter(
+                description=ParadeDB(Match("running shoes", operator="OR"))
+            )
+            .order_by("rating", "id")
+            .values("description", "rating", "category")[:5]
+        )
+        assert len(rows) > 0
+        ratings = [r["rating"] for r in rows]
+        assert ratings == sorted(ratings)
+
+    def test_topn_lower_function_sort(self) -> None:
+        """order_by(Lower('description')) — docs/sorting/topn.mdx snippet 3."""
+        rows = list(
+            MockItem.objects.filter(
+                description=ParadeDB(Match("sleek running shoes", operator="OR"))
+            )
+            .order_by(Lower("description"))
+            .values("description", "rating", "category")[:5]
+        )
+        assert len(rows) > 0
+        descs = [r["description"].lower() for r in rows]
+        assert descs == sorted(descs)
+
+
+class TestBoostAndConstScoring:
+    """Boost and const scoring patterns from docs/sorting/boost.mdx."""
+
+    def test_boost_q_or_with_score_ordering(self) -> None:
+        """Q|Q with boost on one side + Score ordering — docs/sorting/boost.mdx snippet 1."""
+        rows = list(
+            MockItem.objects.filter(
+                Q(description=ParadeDB(Match("shoes", operator="OR", boost=2)))
+                | Q(category=ParadeDB(Match("footwear", operator="OR")))
+            )
+            .annotate(score=Score())
+            .values("id", "score", "description", "category")
+            .order_by("-score")[:5]
+        )
+        assert len(rows) > 0
+        scores = [r["score"] for r in rows]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_boost_regex_with_score_ordering(self) -> None:
+        """Regex + boost + Score ordering — docs/sorting/boost.mdx snippet 2."""
+        rows = list(
+            MockItem.objects.filter(description=ParadeDB(Regex("key.*", boost=2)))
+            .annotate(score=Score())
+            .values("id", "description", "category", "score")
+            .order_by("-score")[:5]
+        )
+        assert len(rows) > 0
+
+    def test_boost_fuzzy_term_with_score_ordering(self) -> None:
+        """Term with fuzzy distance + boost + Score ordering — docs/sorting/boost.mdx snippet 3."""
+        rows = list(
+            MockItem.objects.filter(
+                description=ParadeDB(Term("shose", distance=2, boost=2))
+            )
+            .annotate(score=Score())
+            .values("id", "description", "category", "score")
+            .order_by("-score")[:5]
+        )
+        assert len(rows) > 0
+
+    def test_const_score_with_match(self) -> None:
+        """Match + const=1 + Score ordering — docs/sorting/boost.mdx snippet 4."""
+        rows = list(
+            MockItem.objects.filter(
+                description=ParadeDB(Match("shoes", operator="OR", const=1))
+            )
+            .annotate(score=Score())
+            .values("id", "score", "description", "category")
+            .order_by("-score")[:5]
+        )
+        assert len(rows) > 0
+        scores = [r["score"] for r in rows]
+        assert all(s == pytest.approx(1.0) for s in scores)
+
+
+class TestScoreWithQCombinations:
+    """Score annotation with Q object combinations — docs/sorting/score.mdx."""
+
+    def test_score_q_or_with_standard_filter(self) -> None:
+        """Q(ParadeDB) | Q(rating__lt=2) with Score ordering — docs/sorting/score.mdx snippet 2."""
+        rows = list(
+            MockItem.objects.filter(
+                Q(description=ParadeDB(Match("keyboard", operator="OR")))
+                | Q(rating__lt=2)
+            )
+            .annotate(score=Score())
+            .values("id", "score")
+            .order_by("score")[:5]
+        )
+        assert len(rows) > 0

--- a/tests/integration/test_facets_integration.py
+++ b/tests/integration/test_facets_integration.py
@@ -6,7 +6,7 @@ import pytest
 from django.db import utils as db_utils
 from tests.models import MockItem
 
-from paradedb.search import Match, ParadeDB
+from paradedb.search import Match, ParadeDB, Term
 
 pytestmark = [
     pytest.mark.integration,
@@ -117,3 +117,30 @@ class TestFacetsIntegration:
         assert len(rows) <= 3
         assert "buckets" in facets
         assert facets["buckets"] == []
+
+    def test_facets_agg_with_term_search(self) -> None:
+        """facets(agg=JSON_spec) with Term filter — docs/aggregates/facets.mdx snippet 1."""
+        rows, facets = (
+            MockItem.objects.filter(category=ParadeDB(Term("electronics")))
+            .order_by("-rating")[:3]
+            .facets(agg='{"value_count": {"field": "id"}}')
+        )
+        assert isinstance(rows, list)
+        assert len(rows) <= 3
+        assert isinstance(facets, dict)
+        assert "value" in facets
+        assert facets["value"] > 0
+
+    def test_facets_agg_with_match_search(self) -> None:
+        """facets(agg=JSON_spec) with Match filter — docs/aggregates/facets.mdx snippet 2."""
+        rows, facets = (
+            MockItem.objects.filter(
+                description=ParadeDB(Match("running shoes", operator="OR"))
+            )
+            .order_by("rating")[:5]
+            .facets(agg='{"value_count": {"field": "id"}}')
+        )
+        assert isinstance(rows, list)
+        assert isinstance(facets, dict)
+        assert "value" in facets
+        assert facets["value"] > 0

--- a/tests/integration/test_paradedb_queries.py
+++ b/tests/integration/test_paradedb_queries.py
@@ -8,6 +8,7 @@ from tests.models import MockItem
 
 from paradedb.functions import Snippet
 from paradedb.search import (
+    All,
     Match,
     MoreLikeThis,
     ParadeDB,
@@ -173,6 +174,25 @@ def test_fuzzy_conjunction() -> None:
     assert 3 in ids
 
 
+def test_fuzzy_multi_term_or() -> None:
+    """Multi-term Match with distance uses ARRAY['t1', 't2']::pdb.fuzzy(N) — docs snippet."""
+    qs = MockItem.objects.filter(
+        description=ParadeDB(Match("runing", "shose", operator="OR", distance=2))
+    )
+    ids = _ids(qs)
+    assert len(ids) > 0
+
+
+def test_fuzzy_multi_term_and() -> None:
+    """Multi-term Match AND with distance uses ARRAY['t1', 't2']::pdb.fuzzy(N)."""
+    ids = _ids(
+        MockItem.objects.filter(
+            description=ParadeDB(Match("runing", "shose", operator="AND", distance=2))
+        )
+    )
+    assert len(ids) > 0
+
+
 def test_fuzzy_term_form() -> None:
     ids = _ids(MockItem.objects.filter(description=ParadeDB(Term("shose", distance=2))))
     assert len(ids) > 0
@@ -194,6 +214,36 @@ def test_fuzzy_transposition_cost_one() -> None:
         )
     )
     assert len(ids) > 0
+
+
+def test_fuzzy_multi_term_prefix_and() -> None:
+    """Multi-term Match AND with distance + prefix — docs/full-text/fuzzy.mdx snippet 3."""
+    ids = _ids(
+        MockItem.objects.filter(
+            description=ParadeDB(
+                Match("slee", "rann", operator="AND", distance=1, prefix=True)
+            )
+        )
+    )
+    assert len(ids) > 0
+
+
+def test_all_query() -> None:
+    """All() matches every indexed document — docs/aggregates/overview.mdx snippet 4."""
+    count = MockItem.objects.filter(id=ParadeDB(All())).count()
+    assert count > 0
+
+
+def test_filter_category_in_with_paradedb() -> None:
+    """Term search with category__in filter — docs/filtering.mdx snippet 3."""
+    rows = list(
+        MockItem.objects.filter(
+            description=ParadeDB(Term("shoes")),
+            category__in=["Footwear", "Apparel"],
+        ).values("description", "rating", "category")
+    )
+    for row in rows:
+        assert row["category"] in ("Footwear", "Apparel")
 
 
 def test_tokenizer_override_match() -> None:
@@ -375,35 +425,37 @@ def test_const_multi_term_or_query() -> None:
     assert len(ids) > 0
 
 
-def test_match_tokenizer_and_distance_error_deferred_to_database() -> None:
-    queryset = MockItem.objects.filter(
-        description=ParadeDB(
-            Match(
-                "running shoes",
-                operator="AND",
-                tokenizer="whitespace",
-                distance=1,
-            )
+def test_match_tokenizer_and_distance_rejected() -> None:
+    with pytest.raises(
+        ValueError, match="Match tokenizer cannot be combined with fuzzy options"
+    ):
+        Match(
+            "running shoes",
+            operator="AND",
+            tokenizer="whitespace",
+            distance=1,
         )
-    )
-    with pytest.raises(DatabaseError):
-        list(queryset)
 
 
-def test_multi_term_fuzzy_boost_error_deferred_to_database() -> None:
-    queryset = MockItem.objects.filter(
-        description=ParadeDB(Match("a", "b", operator="OR", distance=1, boost=2.0))
-    )
-    with pytest.raises(DatabaseError):
-        list(queryset)
+def test_multi_term_fuzzy_tokenizer_rejected() -> None:
+    with pytest.raises(
+        ValueError, match="Match tokenizer cannot be combined with fuzzy options"
+    ):
+        Match("a", "b", operator="OR", tokenizer="whitespace", distance=1)
 
 
-def test_multi_term_fuzzy_const_error_deferred_to_database() -> None:
-    queryset = MockItem.objects.filter(
-        description=ParadeDB(Match("a", "b", operator="OR", distance=1, const=1.0))
-    )
-    with pytest.raises(DatabaseError):
-        list(queryset)
+def test_multi_term_fuzzy_boost_rejected() -> None:
+    with pytest.raises(
+        ValueError, match="Multi-term fuzzy Match does not support boost or const"
+    ):
+        Match("a", "b", operator="OR", distance=1, boost=2.0)
+
+
+def test_multi_term_fuzzy_const_rejected() -> None:
+    with pytest.raises(
+        ValueError, match="Multi-term fuzzy Match does not support boost or const"
+    ):
+        Match("a", "b", operator="OR", distance=1, const=1.0)
 
 
 def test_boost_and_const_error_deferred_to_database() -> None:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -198,20 +198,23 @@ class TestDistanceValidation:
         term = Term("test", distance=1)
         assert term.distance == 1
 
-    def test_match_tokenizer_and_fuzzy_options_allowed(self) -> None:
-        match = Match("test", operator="AND", tokenizer="whitespace", distance=1)
-        assert match.tokenizer == "whitespace"
-        assert match.distance == 1
+    def test_match_tokenizer_and_fuzzy_options_rejected(self) -> None:
+        with pytest.raises(
+            ValueError, match="Match tokenizer cannot be combined with fuzzy options"
+        ):
+            Match("test", operator="AND", tokenizer="whitespace", distance=1)
 
-    def test_match_multi_term_fuzzy_with_boost_allowed(self) -> None:
-        match = Match("a", "b", operator="OR", distance=1, boost=2.0)
-        assert match.boost == 2.0
-        assert match.distance == 1
+    def test_match_multi_term_fuzzy_with_boost_rejected(self) -> None:
+        with pytest.raises(
+            ValueError, match="Multi-term fuzzy Match does not support boost or const"
+        ):
+            Match("a", "b", operator="OR", distance=1, boost=2.0)
 
-    def test_match_multi_term_fuzzy_with_const_allowed(self) -> None:
-        match = Match("a", "b", operator="OR", distance=1, const=1.0)
-        assert match.const == 1.0
-        assert match.distance == 1
+    def test_match_multi_term_fuzzy_with_const_rejected(self) -> None:
+        with pytest.raises(
+            ValueError, match="Multi-term fuzzy Match does not support boost or const"
+        ):
+            Match("a", "b", operator="OR", distance=1, const=1.0)
 
     def test_term_non_string_rejected(self) -> None:
         with pytest.raises(TypeError, match="Term text must be a string"):

--- a/tests/test_sql_generation.py
+++ b/tests/test_sql_generation.py
@@ -298,35 +298,28 @@ class TestDistanceOption:
         ):
             Match("x", operator="AND", distance=3)
 
-    def test_match_tokenizer_and_distance_sql_generated(self) -> None:
-        queryset = Product.objects.filter(
-            description=ParadeDB(
-                Match(
-                    "running shoes",
-                    operator="AND",
-                    tokenizer="whitespace",
-                    distance=1,
-                )
+    def test_match_tokenizer_and_distance_rejected(self) -> None:
+        with pytest.raises(
+            ValueError, match="Match tokenizer cannot be combined with fuzzy options"
+        ):
+            Match(
+                "running shoes",
+                operator="AND",
+                tokenizer="whitespace",
+                distance=1,
             )
-        )
-        # Tokenizer is per-term, fuzzy is on the whole array: 'running shoes'::pdb.whitespace::pdb.fuzzy(1)
-        assert "::pdb.whitespace::pdb.fuzzy(1)" in str(queryset.query)
 
-    def test_multi_term_fuzzy_boost_sql_generated(self) -> None:
-        queryset = Product.objects.filter(
-            description=ParadeDB(Match("a", "b", operator="OR", distance=1, boost=2.0))
-        )
-        # Fuzzy applied to whole array, then boost: ARRAY['a', 'b']::pdb.fuzzy(1)::pdb.boost(2.0)
-        assert "ARRAY['a', 'b']::pdb.fuzzy(1)::pdb.boost(2.0)" in str(queryset.query)
+    def test_multi_term_fuzzy_boost_rejected(self) -> None:
+        with pytest.raises(
+            ValueError, match="Multi-term fuzzy Match does not support boost or const"
+        ):
+            Match("a", "b", operator="OR", distance=1, boost=2.0)
 
-    def test_multi_term_fuzzy_const_sql_generated(self) -> None:
-        queryset = Product.objects.filter(
-            description=ParadeDB(Match("a", "b", operator="OR", distance=1, const=1.0))
-        )
-        # Fuzzy applied to whole array, then query bridge for const: ARRAY['a', 'b']::pdb.fuzzy(1)::pdb.query::pdb.const(1.0)
-        assert "ARRAY['a', 'b']::pdb.fuzzy(1)::pdb.query::pdb.const(1.0)" in str(
-            queryset.query
-        )
+    def test_multi_term_fuzzy_const_rejected(self) -> None:
+        with pytest.raises(
+            ValueError, match="Multi-term fuzzy Match does not support boost or const"
+        ):
+            Match("a", "b", operator="OR", distance=1, const=1.0)
 
 
 class TestTokenizerOverride:


### PR DESCRIPTION
# Ticket(s) Closed

- Eager validation in Match: invalid combinations (tokenizer + fuzzy, multi-term fuzzy + boost/const) now raise ValueError at construction time
 - Multi-term fuzzy SQL fix: Match with multiple terms + distance/prefix now correctly generates ARRAY['t1', 't2']::pdb.fuzzy(N) rather than per-element casts that had no matching operator
 - New integration tests for docs snippets: covers All(), multi-term fuzzy OR/AND/prefix, top-N ordering (tiebreaker, Lower()), boost/const scoring, Score() annotation with Q combinations, facets with Term/Match filters, and Django ORM Agg annotations

Mypy/docker vesions. 
## What

## Why

## How

## Tests
