### PR TITLE
ci: add concurrency groups to ci and schema-compat workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres

--- a/.github/workflows/schema-compat.yml
+++ b/.github/workflows/schema-compat.yml
@@ -17,6 +17,10 @@ on:
         description: "ParadeDB version to check against"
         required: true
 
+concurrency:
+  group: schema-compat-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 env:
   PARADEDB_VERSION: ${{ inputs.version || github.event.client_payload.version }}
 


### PR DESCRIPTION
## Summary
- Adds concurrency groups to the two CI workflows that were missing them (`ci.yml` and `schema-compat.yml`), matching the `<name>-${{ github.head_ref || github.ref }}` pattern used in paradedb/paradedb and the other workflows in this repo

## Test plan
- [x] Verify CI workflow triggers correctly and cancels redundant runs on the same branch