### PR TITLE
chore: Use anchor terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ All notable changes to this project will be documented in this file. The format 
   Supports Django expressions (e.g., `Lower('title')`, `F('rating') + 1`) with
   optional tokenizer configuration. For non-text expressions, uses `pdb.alias`.
 
+### Changed
+
+- **BREAKING**: Renamed `ProximityArray` keyword arguments from `right_term` and
+  `right_pattern` to `anchor` and `anchor_pattern`.
+
 ## [0.4.0] - 2026-02-28
 
 ### Added

--- a/paradedb/search.py
+++ b/paradedb/search.py
@@ -328,43 +328,43 @@ class ProxRegex:
 class ProximityArray:
     """Proximity array query expression."""
 
-    left_terms: tuple[str | ProxRegex, ...]
-    right_term: str
+    terms: tuple[str | ProxRegex, ...]
+    anchor: str
     distance: int
     ordered: bool = False
-    right_pattern: str | None = None
+    anchor_pattern: str | None = None
     max_expansions: int = 50
     boost: float | None = None
     const: float | None = None
 
     def __init__(
         self,
-        *left_terms: str | ProxRegex,
-        right_term: str,
+        *terms: str | ProxRegex,
+        anchor: str,
         distance: int,
         ordered: bool = False,
-        right_pattern: str | None = None,
+        anchor_pattern: str | None = None,
         max_expansions: int = 50,
         boost: float | None = None,
         const: float | None = None,
     ) -> None:
-        if not left_terms:
+        if not terms:
             raise ValueError("ProximityArray requires at least one left-side term.")
-        for left_term in left_terms:
+        for left_term in terms:
             if not isinstance(left_term, str | ProxRegex):
                 raise TypeError(
-                    "ProximityArray left_terms must be strings or ProxRegex instances."
+                    "ProximityArray terms must be strings or ProxRegex instances."
                 )
-        _validate_string("ProximityArray right_term", right_term)
+        _validate_string("ProximityArray anchor", anchor)
         _validate_non_negative_int("ProximityArray distance", distance)
         _validate_non_negative_int("ProximityArray max_expansions", max_expansions)
-        if right_pattern is not None:
-            _validate_string("ProximityArray right_pattern", right_pattern)
-        object.__setattr__(self, "left_terms", tuple(left_terms))
-        object.__setattr__(self, "right_term", right_term)
+        if anchor_pattern is not None:
+            _validate_string("ProximityArray anchor_pattern", anchor_pattern)
+        object.__setattr__(self, "terms", tuple(terms))
+        object.__setattr__(self, "anchor", anchor)
         object.__setattr__(self, "distance", distance)
         object.__setattr__(self, "ordered", ordered)
-        object.__setattr__(self, "right_pattern", right_pattern)
+        object.__setattr__(self, "anchor_pattern", anchor_pattern)
         object.__setattr__(self, "max_expansions", max_expansions)
         object.__setattr__(self, "boost", boost)
         object.__setattr__(self, "const", const)
@@ -1413,7 +1413,7 @@ class ParadeDB:
             return self._append_scoring(rendered, boost=term.boost, const=term.const)
         if isinstance(term, ProximityArray):
             left_parts: list[str] = []
-            for lt in term.left_terms:
+            for lt in term.terms:
                 if isinstance(lt, ProxRegex):
                     left_parts.append(
                         f"{FN_PROX_REGEX}({self._quote_term(lt.pattern)}, {lt.max_expansions})"
@@ -1422,9 +1422,9 @@ class ParadeDB:
                     left_parts.append(self._quote_term(lt))
             left_sql = ", ".join(left_parts)
             operator = OP_PROXIMITY_ORD if term.ordered else OP_PROXIMITY
-            right_sql = self._quote_term(term.right_term)
-            if term.right_pattern is not None:
-                right_sql = f"{FN_PROX_REGEX}({self._quote_term(term.right_pattern)}, {term.max_expansions})"
+            right_sql = self._quote_term(term.anchor)
+            if term.anchor_pattern is not None:
+                right_sql = f"{FN_PROX_REGEX}({self._quote_term(term.anchor_pattern)}, {term.max_expansions})"
             rendered = (
                 f"{FN_PROXIMITY}("
                 f"{FN_PROX_ARRAY}({left_sql}) {operator} {term.distance} {operator} {right_sql}"

--- a/tests/integration/test_paradedb_queries.py
+++ b/tests/integration/test_paradedb_queries.py
@@ -140,7 +140,7 @@ def test_proximity_array_query() -> None:
     ids = _ids(
         MockItem.objects.filter(
             description=ParadeDB(
-                ProximityArray("sleek", "running", right_term="shoes", distance=1)
+                ProximityArray("sleek", "running", anchor="shoes", distance=1)
             )
         )
     )
@@ -154,7 +154,7 @@ def test_proximity_array_with_mixed_prox_regex_items() -> None:
                 ProximityArray(
                     "sleek",
                     ProxRegex("run.*"),
-                    right_term="shoes",
+                    anchor="shoes",
                     distance=1,
                 )
             )
@@ -170,7 +170,7 @@ def test_proximity_array_with_mixed_prox_regex_items_ordered() -> None:
                 ProximityArray(
                     "sleek",
                     ProxRegex("run.*"),
-                    right_term="shoes",
+                    anchor="shoes",
                     distance=1,
                     ordered=True,
                 )
@@ -184,7 +184,7 @@ def test_proximity_array_with_only_prox_regex_left_term() -> None:
     ids = _ids(
         MockItem.objects.filter(
             description=ParadeDB(
-                ProximityArray(ProxRegex("run.*"), right_term="shoes", distance=1)
+                ProximityArray(ProxRegex("run.*"), anchor="shoes", distance=1)
             )
         )
     )
@@ -197,7 +197,7 @@ def test_proximity_array_with_prox_regex_custom_max_expansions() -> None:
             description=ParadeDB(
                 ProximityArray(
                     ProxRegex("run.*", max_expansions=100),
-                    right_term="shoes",
+                    anchor="shoes",
                     distance=1,
                 )
             )
@@ -224,16 +224,16 @@ def test_proximity_array_with_prox_regex_non_string_pattern() -> None:
 def test_proximity_array_with_non_string_left_term() -> None:
     with pytest.raises(
         TypeError,
-        match="ProximityArray left_terms must be strings or ProxRegex instances",
+        match="ProximityArray terms must be strings or ProxRegex instances",
     ):
-        ProximityArray(123, right_term="shoes", distance=1)  # type: ignore[arg-type]
+        ProximityArray(123, anchor="shoes", distance=1)  # type: ignore[arg-type]
 
 
 def test_proximity_array_with_invalid_prox_regex_pattern_raises() -> None:
     with pytest.raises(DatabaseError, match="regex parse error"):
         MockItem.objects.filter(
             description=ParadeDB(
-                ProximityArray(ProxRegex("[invalid"), right_term="shoes", distance=1)
+                ProximityArray(ProxRegex("[invalid"), anchor="shoes", distance=1)
             )
         ).exists()
 

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -348,31 +348,31 @@ class TestExpressionValidation:
 
     def test_proximity_array_requires_left_terms(self) -> None:
         with pytest.raises(ValueError, match="requires at least one left-side term"):
-            ProximityArray(right_term="right", distance=1)
+            ProximityArray(anchor="right", distance=1)
 
     def test_proximity_array_negative_distance_raises(self) -> None:
         with pytest.raises(ValueError, match="distance must be zero or positive"):
-            ProximityArray("left", right_term="right", distance=-1)
+            ProximityArray("left", anchor="right", distance=-1)
 
     def test_proximity_array_negative_max_expansions_raises(self) -> None:
         with pytest.raises(ValueError, match="max_expansions must be zero or positive"):
-            ProximityArray("left", right_term="right", distance=1, max_expansions=-1)
+            ProximityArray("left", anchor="right", distance=1, max_expansions=-1)
 
     def test_proximity_array_boost_and_const_deferred_to_database(self) -> None:
         proximity_array = ProximityArray(
-            "left", right_term="right", distance=1, boost=1.0, const=1.0
+            "left", anchor="right", distance=1, boost=1.0, const=1.0
         )
         assert proximity_array.boost == 1.0
         assert proximity_array.const == 1.0
 
     def test_proximity_array_accepts_prox_regex_items(self) -> None:
         proximity_array = ProximityArray(
-            "chicken", ProxRegex("r..s"), right_term="delicious", distance=1
+            "chicken", ProxRegex("r..s"), anchor="delicious", distance=1
         )
-        assert len(proximity_array.left_terms) == 2
-        assert proximity_array.left_terms[0] == "chicken"
-        assert isinstance(proximity_array.left_terms[1], ProxRegex)
-        assert proximity_array.left_terms[1].pattern == "r..s"
+        assert len(proximity_array.terms) == 2
+        assert proximity_array.terms[0] == "chicken"
+        assert isinstance(proximity_array.terms[1], ProxRegex)
+        assert proximity_array.terms[1].pattern == "r..s"
 
     def test_prox_regex_negative_max_expansions_raises(self) -> None:
         with pytest.raises(ValueError, match="max_expansions must be zero or positive"):
@@ -394,9 +394,9 @@ class TestExpressionValidation:
     def test_proximity_array_left_terms_must_be_strings_or_proxregex(self) -> None:
         with pytest.raises(
             TypeError,
-            match="left_terms must be strings or ProxRegex instances",
+            match="terms must be strings or ProxRegex instances",
         ):
-            ProximityArray(123, right_term="right", distance=1)  # type: ignore[arg-type]
+            ProximityArray(123, anchor="right", distance=1)  # type: ignore[arg-type]
 
 
 class TestMoreLikeThisValidation:

--- a/tests/test_sql_generation.py
+++ b/tests/test_sql_generation.py
@@ -627,7 +627,7 @@ class TestProximityAdvancedQuery:
     def test_proximity_array_query(self) -> None:
         queryset = Product.objects.filter(
             description=ParadeDB(
-                ProximityArray("sleek", "running", right_term="shoes", distance=1)
+                ProximityArray("sleek", "running", anchor="shoes", distance=1)
             )
         )
         assert (
@@ -641,7 +641,7 @@ class TestProximityAdvancedQuery:
                 ProximityArray(
                     "chicken",
                     ProxRegex("r..s"),
-                    right_term="delicious",
+                    anchor="delicious",
                     distance=1,
                 )
             )
@@ -657,7 +657,7 @@ class TestProximityAdvancedQuery:
                 ProximityArray(
                     ProxRegex("sl.*", max_expansions=100),
                     "white",
-                    right_term="shoes",
+                    anchor="shoes",
                     distance=1,
                 )
             )
@@ -672,8 +672,8 @@ class TestProximityAdvancedQuery:
             description=ParadeDB(
                 ProximityArray(
                     "running",
-                    right_term="unused",
-                    right_pattern="sho.*",
+                    anchor="unused",
+                    anchor_pattern="sho.*",
                     distance=1,
                     max_expansions=80,
                 )


### PR DESCRIPTION
Use `anchor` terminology instead of `right_term` to make the naming consistent with the naming in the rails integration.