### PR TITLE
chore: remove Slack notification from schema-compat workflow

### DIFF
--- a/.github/workflows/schema-compat.yml
+++ b/.github/workflows/schema-compat.yml
@@ -129,9 +129,3 @@ jobs:
           EOF
           )" \
             --label bug
-
-      - name: Notify Slack on Failure
-        run: |
-          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`schema-compat\` workflow failed for ParadeDB v${{ env.PARADEDB_VERSION }} in \`${{ github.repository }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
-          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary
- Removes the redundant Slack notification step from the `schema-compat.yml` workflow's `notify` job
- GitHub issue creation already covers failure notifications

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Confirm the `notify` job still creates a GitHub issue on failure