### PR TITLE
feat: Clean up rendering logic to remove unnecessary error states

### DIFF
--- a/paradedb/search.py
+++ b/paradedb/search.py
@@ -292,11 +292,12 @@ class ProxRegex:
     """Regex clause for use inside a proximity expression."""
 
     pattern: str
-    max_expansions: int = 50
+    max_expansions: int | None = None
 
     def __post_init__(self) -> None:
         _validate_string("ProxRegex pattern", self.pattern)
-        _validate_non_negative_int("ProxRegex max_expansions", self.max_expansions)
+        if self.max_expansions is not None:
+            _validate_non_negative_int("ProxRegex max_expansions", self.max_expansions)
 
 
 ProximityTerm: TypeAlias = str | ProxRegex | list["ProximityTerm"]
@@ -1124,6 +1125,8 @@ class ParadeDB:
         if isinstance(term, str):
             return self._quote_term(term)
         if isinstance(term, ProxRegex):
+            if term.max_expansions is None:
+                return f"{FN_PROX_REGEX}({self._quote_term(term.pattern)})"
             return f"{FN_PROX_REGEX}({self._quote_term(term.pattern)}, {term.max_expansions})"
         if isinstance(term, list):
             parts = [self._render_proximity_term(x) for x in term]

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -357,7 +357,7 @@ class TestExpressionValidation:
     def test_prox_regex_defaults(self) -> None:
         prox_regex = ProxRegex("pattern")
         assert prox_regex.pattern == "pattern"
-        assert prox_regex.max_expansions == 50
+        assert prox_regex.max_expansions is None
 
     def test_proximity_start_must_be_strings_or_proxregex(self) -> None:
         with pytest.raises(

--- a/tests/test_sql_generation.py
+++ b/tests/test_sql_generation.py
@@ -596,7 +596,7 @@ class TestProximityAdvancedQuery:
         )
         assert (
             str(queryset.query)
-            == 'SELECT "tests_product"."id", "tests_product"."description", "tests_product"."category", "tests_product"."rating", "tests_product"."in_stock", "tests_product"."price", "tests_product"."created_at", "tests_product"."metadata" FROM "tests_product" WHERE "tests_product"."description" @@@ (\'running\' ## 1 ## pdb.prox_regex(\'sho.*\', 50))'
+            == 'SELECT "tests_product"."id", "tests_product"."description", "tests_product"."category", "tests_product"."rating", "tests_product"."in_stock", "tests_product"."price", "tests_product"."created_at", "tests_product"."metadata" FROM "tests_product" WHERE "tests_product"."description" @@@ (\'running\' ## 1 ## pdb.prox_regex(\'sho.*\'))'
         )
 
     def test_proximity_array_query(self) -> None:
@@ -616,7 +616,7 @@ class TestProximityAdvancedQuery:
         )
         assert (
             str(queryset.query)
-            == 'SELECT "tests_product"."id", "tests_product"."description", "tests_product"."category", "tests_product"."rating", "tests_product"."in_stock", "tests_product"."price", "tests_product"."created_at", "tests_product"."metadata" FROM "tests_product" WHERE "tests_product"."description" @@@ (pdb.prox_array(\'chicken\', pdb.prox_regex(\'r..s\', 50)) ## 1 ## \'delicious\')'
+            == 'SELECT "tests_product"."id", "tests_product"."description", "tests_product"."category", "tests_product"."rating", "tests_product"."in_stock", "tests_product"."price", "tests_product"."created_at", "tests_product"."metadata" FROM "tests_product" WHERE "tests_product"."description" @@@ (pdb.prox_array(\'chicken\', pdb.prox_regex(\'r..s\')) ## 1 ## \'delicious\')'
         )
 
     def test_proximity_array_with_prox_regex_custom_expansions(self) -> None:
@@ -671,7 +671,7 @@ class TestProximityAdvancedQuery:
         )
         assert (
             str(queryset.query)
-            == 'SELECT "tests_product"."id", "tests_product"."description", "tests_product"."category", "tests_product"."rating", "tests_product"."in_stock", "tests_product"."price", "tests_product"."created_at", "tests_product"."metadata" FROM "tests_product" WHERE "tests_product"."description" @@@ (pdb.prox_regex(\'sho.*\', 50) ##> 1 ##> pdb.prox_array(\'history\', \'science\') ## 5 ## \'hardcover\')'
+            == 'SELECT "tests_product"."id", "tests_product"."description", "tests_product"."category", "tests_product"."rating", "tests_product"."in_stock", "tests_product"."price", "tests_product"."created_at", "tests_product"."metadata" FROM "tests_product" WHERE "tests_product"."description" @@@ (pdb.prox_regex(\'sho.*\') ##> 1 ##> pdb.prox_array(\'history\', \'science\') ## 5 ## \'hardcover\')'
         )
 
     def test_proximity_nested_child_constructor_query(self) -> None:
@@ -721,7 +721,7 @@ class TestProximityAdvancedQuery:
         )
         assert (
             str(queryset.query)
-            == 'SELECT "tests_product"."id", "tests_product"."description", "tests_product"."category", "tests_product"."rating", "tests_product"."in_stock", "tests_product"."price", "tests_product"."created_at", "tests_product"."metadata" FROM "tests_product" WHERE "tests_product"."description" @@@ (\'running\' ## 2 ## (pdb.prox_array(\'shoes\', pdb.prox_regex(\'sho.*\', 50), pdb.prox_array(\'shoe\', pdb.prox_array(pdb.prox_regex(\'shoe\', 50)))) ##> 4 ##> \'hardcover\' ## 100 ## \'foo\') ## 2 ## pdb.prox_regex(\'bar\', 50))::pdb.boost(1.2)'
+            == 'SELECT "tests_product"."id", "tests_product"."description", "tests_product"."category", "tests_product"."rating", "tests_product"."in_stock", "tests_product"."price", "tests_product"."created_at", "tests_product"."metadata" FROM "tests_product" WHERE "tests_product"."description" @@@ (\'running\' ## 2 ## (pdb.prox_array(\'shoes\', pdb.prox_regex(\'sho.*\'), pdb.prox_array(\'shoe\', pdb.prox_array(pdb.prox_regex(\'shoe\')))) ##> 4 ##> \'hardcover\' ## 100 ## \'foo\') ## 2 ## pdb.prox_regex(\'bar\'))::pdb.boost(1.2)'
         )
 
 


### PR DESCRIPTION
# Ticket(s) Closed

## What
Clean up the rendering logic.

I also slipped in a change to stop setting a default value for `max_expansions` in the code and instead let the DB do that to make sure it doesn't get out of sync.

## Why
This removes some unnecessary error states and makes the API clearer for users. For example, before this the main `ParadeDB` object's constructor accepted several fields that were not intended to be set and threw exceptions if they were. These could all be removed to make it clear to users that they aren't part of the API surface.

This change also allowed me to remove a lot of unnecessary code and will make the code easier to change in the future.

## How
- Update `ParadeDB` to accept only one term as an argument instead of varargs (which were not used anywhere).
- Render `Match` as a stand alone term like every other query instead of breaking it down into string literals and putting the logic elsewhere.

## Tests
Existing tests cover this behavior. Several tests could be removed because they error states they were testing are no longer possible.
