### PR TITLE
fix: implement equality comparison for Tokenizer class

### DIFF
--- a/paradedb/search.py
+++ b/paradedb/search.py
@@ -131,6 +131,15 @@ class Tokenizer:
         self.positional_arguments = params
         self.options = options
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Tokenizer):
+            return NotImplemented
+        return (
+            self.name == other.name
+            and self.positional_arguments == other.positional_arguments
+            and self.options == other.options
+        )
+
     @staticmethod
     def unicode_words(
         options: _TOKENIZER_OPTIONS | None = None,

--- a/tests/test_index_validation.py
+++ b/tests/test_index_validation.py
@@ -70,3 +70,24 @@ def test_native_json_fields_on_non_json_field_raises_value_error() -> None:
     )
     with pytest.raises(ValueError, match="is not a JSONField"):
         index.create_sql(model=Product, schema_editor=DummySchemaEditor())
+
+
+def test_bm25_index_with_equivalent_tokenizers_compares_equal() -> None:
+    left = BM25Index(
+        fields={
+            "id": {},
+            "description": {"tokenizer": Tokenizer.unicode_words()},
+        },
+        key_field="id",
+        name="product_search_idx",
+    )
+    right = BM25Index(
+        fields={
+            "id": {},
+            "description": {"tokenizer": Tokenizer.unicode_words()},
+        },
+        key_field="id",
+        name="product_search_idx",
+    )
+
+    assert left == right

--- a/tests/test_index_validation.py
+++ b/tests/test_index_validation.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from unittest.mock import Mock
 
 import pytest
+from django.db import models
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.autodetector import MigrationAutodetector
+from django.db.migrations.graph import MigrationGraph
+from django.db.migrations.questioner import NonInteractiveMigrationQuestioner
+from django.db.migrations.state import ModelState, ProjectState
 
 from paradedb.indexes import BM25Index
 from paradedb.search import Tokenizer
@@ -91,3 +96,60 @@ def test_bm25_index_with_equivalent_tokenizers_compares_equal() -> None:
     )
 
     assert left == right
+
+
+def test_repeated_makemigrations_does_not_recreate_tokenizer_indexes() -> None:
+    # Use this function to create a fresh instance of the project state, importantly with
+    # a fresh instance of Tokenizer.simple()
+    def product_state() -> ProjectState:
+        state = ProjectState()
+        state.add_model(
+            ModelState(
+                "tests",
+                "MigrationProduct",
+                fields=[
+                    ("id", models.AutoField(primary_key=True)),
+                    ("description", models.TextField()),
+                ],
+                options={
+                    "indexes": [
+                        BM25Index(
+                            fields={
+                                "id": {},
+                                "description": {"tokenizer": Tokenizer.simple()},
+                            },
+                            key_field="id",
+                            name="migration_product_search_idx",
+                        )
+                    ],
+                },
+            )
+        )
+        return state
+
+    questioner = NonInteractiveMigrationQuestioner(
+        specified_apps={"tests"},
+        dry_run=True,
+    )
+    graph = MigrationGraph()
+    initial_changes = MigrationAutodetector(
+        ProjectState(),
+        product_state(),
+        questioner,
+    ).changes(graph=graph, trim_to_apps={"tests"})
+    initial_migration = initial_changes["tests"][0]
+    graph.add_node(("tests", initial_migration.name), initial_migration)
+
+    migrated_state = ProjectState()
+    for operation in initial_migration.operations:
+        operation.state_forwards("tests", migrated_state)
+
+    for _ in range(3):
+        changes = MigrationAutodetector(
+            migrated_state,
+            product_state(),
+            questioner,
+        ).changes(graph=graph, trim_to_apps={"tests"})
+
+        # Applying the same configuration repeatedly should yield no changes
+        assert changes == {}


### PR DESCRIPTION
## Summary

Adds value-based equality to `Tokenizer`.

`Tokenizer` is already `@deconstructible`, so Django can serialize it into migrations. However, `BM25Index.deconstruct()` includes `fields_config`, which may contain `Tokenizer` instances. Django compares index definitions by comparing their deconstructed values during migration autodetection. Without `Tokenizer.__eq__`, two equivalent tokenizer instances compare unequal by identity, causing Django to repeatedly detect unchanged BM25 indexes as changed.

## Reproduction

I came across this while using the library, trying to use `makemigrations`. I created a minimal demo repo showing the issue:

https://github.com/Cruel/django-paradedb-bug-demo

Run `uv run manage.py makemigrations` in the repo repeatedly.

It will keep making the same migration file over and over, never realizing the indices are equal. This PR should fix this.