### PR TITLE
chore: Ignore pdb.query to fix schema compat

### DIFF
--- a/apiignore.json5
+++ b/apiignore.json5
@@ -274,6 +274,7 @@
   ],
 
   "types": [
-    "pdb.proximityclause"
+    "pdb.proximityclause",
+    "pdb.query",
   ]
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #131

## What

`pdb.query` was only included in the past as a workaround to get casts between boost/const and fuzzy working. Now that that's been fixed it's unused. It just needed to be added to the ignore file

## Why

## How

## Tests
