### PR TITLE
feat: Remove multi-id support from more like this

### DIFF
--- a/examples/more_like_this/more_like_this.py
+++ b/examples/more_like_this/more_like_this.py
@@ -13,6 +13,8 @@ Use cases:
 import sys
 from pathlib import Path
 
+from django.db.models import Q
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from common import MockItem, setup_mock_items
@@ -74,7 +76,9 @@ def demo_similar_to_multiple_products() -> None:
     print("\nRecommended products (similar to any browsed item):")
     similar = (
         MockItem.objects.filter(
-            id=ParadeDB(MoreLikeThis(ids=browsed_ids, fields=["description"]))
+            Q(id=ParadeDB(MoreLikeThis(id=3, fields=["description"])))
+            | Q(id=ParadeDB(MoreLikeThis(id=12, fields=["description"])))
+            | Q(id=ParadeDB(MoreLikeThis(id=29, fields=["description"])))
         )
         .exclude(id__in=browsed_ids)  # Exclude already-viewed items
         .annotate(score=Score())

--- a/paradedb/search.py
+++ b/paradedb/search.py
@@ -602,7 +602,6 @@ class MoreLikeThis(Expression):
         self,
         *,
         id: int | None = None,
-        ids: Iterable[int] | None = None,
         document: dict[str, Any] | str | None = None,
         fields: Iterable[str] | None = None,
         key_field: str | None = None,
@@ -617,7 +616,6 @@ class MoreLikeThis(Expression):
     ) -> None:
         super().__init__()
         self.id = id
-        self.ids = list(ids) if ids is not None else None
         self.document: str | None = None
         self._document_input = document
         self.fields = list(fields) if fields is not None else None
@@ -654,7 +652,6 @@ class MoreLikeThis(Expression):
         return sum(
             [
                 self.id is not None,
-                self.ids is not None,
                 self._document_input is not None,
             ]
         )
@@ -664,15 +661,6 @@ class MoreLikeThis(Expression):
             isinstance(self.id, bool) or not isinstance(self.id, int)
         ):
             raise TypeError("MoreLikeThis id must be an integer.")
-
-        if self.ids is not None and not self.ids:
-            raise ValueError("MoreLikeThis ids cannot be empty.")
-
-        if self.ids is not None and any(
-            isinstance(item_id, bool) or not isinstance(item_id, int)
-            for item_id in self.ids
-        ):
-            raise TypeError("MoreLikeThis ids must contain integers.")
 
     def _validate_key_field(self) -> None:
         if self.key_field is not None and not isinstance(self.key_field, str):
@@ -741,15 +729,6 @@ class MoreLikeThis(Expression):
 
 def render_more_like_this(term: MoreLikeThis, lhs_sql: str) -> tuple[str, list[Any]]:
     params: list[Any] = []
-
-    if term.ids is not None:
-        expressions = []
-        for value in term.ids:
-            mlt_sql, mlt_params = _render_more_like_this_call(term, value)
-            expressions.append(f"{lhs_sql} {OP_SEARCH} {mlt_sql}")
-            params.extend(mlt_params)
-        joined = " OR ".join(expressions)
-        return f"({joined})", params
 
     if term.id is not None:
         mlt_sql, mlt_params = _render_more_like_this_call(term, term.id)

--- a/paradedb/search.py
+++ b/paradedb/search.py
@@ -601,7 +601,7 @@ class MoreLikeThis(Expression):
     def __init__(
         self,
         *,
-        id: int | None = None,
+        id: object | None = None,
         document: dict[str, Any] | str | None = None,
         fields: Iterable[str] | None = None,
         key_field: str | None = None,
@@ -635,7 +635,6 @@ class MoreLikeThis(Expression):
         if self._count_inputs() != 1:
             raise ValueError("MoreLikeThis requires exactly one input source.")
 
-        self._validate_id_inputs()
         self._validate_key_field()
         self._validate_fields()
         self._validate_stopwords()
@@ -655,12 +654,6 @@ class MoreLikeThis(Expression):
                 self._document_input is not None,
             ]
         )
-
-    def _validate_id_inputs(self) -> None:
-        if self.id is not None and (
-            isinstance(self.id, bool) or not isinstance(self.id, int)
-        ):
-            raise TypeError("MoreLikeThis id must be an integer.")
 
     def _validate_key_field(self) -> None:
         if self.key_field is not None and not isinstance(self.key_field, str):
@@ -741,22 +734,15 @@ def render_more_like_this(term: MoreLikeThis, lhs_sql: str) -> tuple[str, list[A
 
 
 def _render_more_like_this_call(
-    term: MoreLikeThis, value: int | str | None
+    term: MoreLikeThis, value: object
 ) -> tuple[str, list[Any]]:
     args: list[str] = []
     params: list[Any] = []
 
-    if isinstance(value, str):
-        # This is a JSON document - use parameter
-        args.append("%s")
-        params.append(value)
-    else:
-        # This is an integer ID - use parameter for safety
-        args.append("%s")
-        params.append(value)
+    args.append("%s")
+    params.append(value)
 
-    if term.fields and not isinstance(value, str):
-        # Fields array only valid for ID-based queries
+    if term.fields:
         # Build parameterized array
         field_placeholders = ", ".join("%s" for _ in term.fields)
         args.append(f"ARRAY[{field_placeholders}]::text[]")

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -300,13 +300,6 @@ class TestMoreLikeThisValidation:
         mlt = MoreLikeThis(id=1)
         assert mlt.id == 1
 
-    def test_mlt_id_must_be_integer(self) -> None:
-        with pytest.raises(TypeError, match="id must be an integer"):
-            MoreLikeThis(id="1")  # type: ignore[arg-type]
-
-        with pytest.raises(TypeError, match="id must be an integer"):
-            MoreLikeThis(id=True)  # type: ignore[arg-type]
-
     def test_mlt_document_dict(self) -> None:
         """MLT with document dict works."""
         mlt = MoreLikeThis(document={"description": "running shoes"})

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -295,11 +295,6 @@ class TestMoreLikeThisValidation:
         with pytest.raises(ValueError, match="exactly one input"):
             MoreLikeThis(id=1, document={"description": "test"})
 
-    def test_mlt_empty_ids_raises(self) -> None:
-        """MLT with empty ids raises ValueError."""
-        with pytest.raises(ValueError, match="cannot be empty"):
-            MoreLikeThis(ids=[])
-
     def test_mlt_single_id(self) -> None:
         """MLT with single id works."""
         mlt = MoreLikeThis(id=1)
@@ -311,18 +306,6 @@ class TestMoreLikeThisValidation:
 
         with pytest.raises(TypeError, match="id must be an integer"):
             MoreLikeThis(id=True)  # type: ignore[arg-type]
-
-    def test_mlt_ids_list(self) -> None:
-        """MLT with ids list works."""
-        mlt = MoreLikeThis(ids=[1, 2, 3])
-        assert mlt.ids == [1, 2, 3]
-
-    def test_mlt_ids_must_contain_integers(self) -> None:
-        with pytest.raises(TypeError, match="ids must contain integers"):
-            MoreLikeThis(ids=[1, "2"])  # type: ignore[list-item]
-
-        with pytest.raises(TypeError, match="ids must contain integers"):
-            MoreLikeThis(ids=[1, True])  # type: ignore[list-item]
 
     def test_mlt_document_dict(self) -> None:
         """MLT with document dict works."""

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -274,14 +274,6 @@ class TestMoreLikeThis:
         )
         _run_query(queryset)
 
-    def test_mlt_multiple_ids(self) -> None:
-        queryset = MockItem.objects.filter(id=ParadeDB(MoreLikeThis(ids=[5, 12, 23])))
-        assert (
-            str(queryset.query)
-            == 'SELECT "mock_items"."id", "mock_items"."description", "mock_items"."category", "mock_items"."rating", "mock_items"."in_stock", "mock_items"."created_at", "mock_items"."metadata" FROM "mock_items" WHERE ("mock_items"."id" @@@ pdb.more_like_this(5) OR "mock_items"."id" @@@ pdb.more_like_this(12) OR "mock_items"."id" @@@ pdb.more_like_this(23))'
-        )
-        _run_query(queryset)
-
     def test_mlt_with_options(self) -> None:
         queryset = MockItem.objects.filter(
             id=ParadeDB(

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -274,7 +274,7 @@ class TestMoreLikeThis:
         )
         _run_query(queryset)
 
-    def test_mlt_with_options(self) -> None:
+    def test_mlt_with_integer_id_and_options(self) -> None:
         queryset = MockItem.objects.filter(
             id=ParadeDB(
                 MoreLikeThis(
@@ -293,7 +293,34 @@ class TestMoreLikeThis:
             str(queryset.query)
             == 'SELECT "mock_items"."id", "mock_items"."description", "mock_items"."category", "mock_items"."rating", "mock_items"."in_stock", "mock_items"."created_at", "mock_items"."metadata" FROM "mock_items" WHERE "mock_items"."id" @@@ pdb.more_like_this(5, ARRAY[description]::text[], min_term_frequency => 2, max_query_terms => 10, min_doc_frequency => 1, min_word_length => 3, max_word_length => 20, stopwords => ARRAY[the, and, or])'
         )
-        _run_query(queryset)
+
+    def test_mlt_string_id_with_options(self) -> None:
+        queryset = MockItem.objects.filter(
+            id=ParadeDB(
+                MoreLikeThis(
+                    id="foo",
+                    fields=["description"],
+                    min_term_freq=2,
+                    max_query_terms=10,
+                    min_doc_freq=1,
+                    min_word_length=3,
+                    max_word_length=20,
+                    stopwords=["the", "and", "or"],
+                )
+            )
+        )
+
+        sql, params = queryset.query.sql_with_params()
+
+        _assert_sql(
+            sql,
+            """
+            SELECT "mock_items"."id", "mock_items"."description", "mock_items"."category", "mock_items"."rating", "mock_items"."in_stock", "mock_items"."created_at", "mock_items"."metadata"
+            FROM "mock_items"
+            WHERE "mock_items"."id" @@@ pdb.more_like_this(%s, ARRAY[%s]::text[], min_term_frequency => 2, max_query_terms => 10, min_doc_frequency => 1, min_word_length => 3, max_word_length => 20, stopwords => ARRAY[%s, %s, %s])
+            """,
+        )
+        assert params == ("foo", "description", "the", "and", "or")
 
 
 class TestExactLiteralDisjunction:


### PR DESCRIPTION
# Ticket(s) Closed

Previously you could pass in multiple IDs to a more like this query and under the hood `id @@@ pdb.more_like_this(1) OR id @@@ pdb.more_like_this(2)` would be generated under the hood. I think this is a bit deceptive, clutters up the API surface, and doesn't map well to the underying API. The other ORMs don't support this either (except for SQLAlchemy), so I removed it.

The id parameter for a more like this query also doesn't have to be an integer, so I relaxed that restriction.

## What

## Why

## How

## Tests
