### PR TITLE
fix: remove dead IndexExpression config fields and unreachable JSON-key tokenizer error

### DIFF
--- a/paradedb/indexes.py
+++ b/paradedb/indexes.py
@@ -123,15 +123,16 @@ class IndexExpression:
     For text expressions, specify a tokenizer. For non-text expressions
     (integers, timestamps, etc.), omit the tokenizer to use ``pdb.alias``.
 
+    Tokenizer configuration (positional args, named args, token filters,
+    stemmer, etc.) is supplied directly on the ``tokenizer`` object via
+    :class:`~paradedb.search.Tokenizer` factory methods (e.g.
+    ``Tokenizer.simple(options={'stemmer': 'english'})``).
+
     Args:
         expression: A Django expression to index (e.g., ``Lower('title')``).
         alias: Required. The name used to reference this expression in queries.
         tokenizer: Tokenizer for text expressions (e.g., 'simple', 'unicode_words').
             Omit for non-text expressions to use ``pdb.alias``.
-        args: Positional arguments for the tokenizer.
-        named_args: Named arguments for the tokenizer configuration.
-        filters: Token filters (e.g., ['lowercase', 'stemmer']).
-        stemmer: Stemmer language (e.g., 'english').
 
     Example::
 
@@ -162,10 +163,6 @@ class IndexExpression:
     expression: Expression | str
     alias: str
     tokenizer: Tokenizer | None = None
-    args: list[Any] | None = None
-    named_args: dict[str, Any] | None = None
-    filters: list[str] | None = None
-    stemmer: str | None = None
 
 
 class BM25Index(models.Index):
@@ -275,8 +272,7 @@ class BM25Index(models.Index):
                 if tokenizer is not None or alias is not None:
                     raise ValueError(
                         f"Field {field_name!r} cannot mix 'tokenizers' with "
-                        f"'tokenizer', 'args', 'named_args', 'filters', "
-                        f"'stemmer', or 'alias'."
+                        f"'tokenizer' or 'alias'."
                     )
                 expressions.extend(
                     self._build_multi_tokenizer_expressions(
@@ -373,13 +369,13 @@ class BM25Index(models.Index):
         expressions: list[str] = []
         for key, config in json_keys.items():
             tokenizer = config.get("tokenizer")
-            if not isinstance(tokenizer, Tokenizer):
-                raise TypeError("tokenizer must be a Tokenizer")
             if tokenizer is None:
                 raise ValueError(
                     f"JSON key {key!r} in field {field_name!r} requires an explicit "
                     f"tokenizer (e.g. 'unicode_words', 'simple', 'literal')."
                 )
+            if not isinstance(tokenizer, Tokenizer):
+                raise TypeError("tokenizer must be a Tokenizer")
             key_literal = _quote_term(key)
             expressions.append(f"(({column}->>{key_literal})::{tokenizer.render()})")
         return expressions

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -52,13 +52,30 @@ def test_tokenizers_mixed_with_top_level_tokenizer_config_raises_value_error() -
         index.create_sql(model=MockItem, schema_editor=DummySchemaEditor())
 
 
-def test_json_key_without_tokenizer_raises_type_error() -> None:
+def test_json_key_without_tokenizer_raises_value_error() -> None:
     index = BM25Index(
         fields={
             "id": {},
             "metadata": {
                 "json_keys": {
                     "color": {},
+                }
+            },
+        },
+        key_field="id",
+        name="mock_items_search_idx",
+    )
+    with pytest.raises(ValueError, match="requires an explicit"):
+        index.create_sql(model=MockItem, schema_editor=DummySchemaEditor())
+
+
+def test_json_key_with_invalid_tokenizer_type_raises_type_error() -> None:
+    index = BM25Index(
+        fields={
+            "id": {},
+            "metadata": {
+                "json_keys": {
+                    "color": {"tokenizer": "simple"},
                 }
             },
         },
@@ -273,7 +290,7 @@ class TestBM25Index:
         )
 
     def test_json_key_without_tokenizer_raises(self) -> None:
-        """JSON keys without an explicit tokenizer raise TypeError."""
+        """JSON keys without an explicit tokenizer raise a descriptive ValueError."""
         index = BM25Index(
             fields={
                 "id": {},
@@ -287,7 +304,7 @@ class TestBM25Index:
             name="mock_items_search_idx",
         )
         schema_editor = _schema_editor()
-        with pytest.raises(TypeError, match="tokenizer must be a Tokenizer"):
+        with pytest.raises(ValueError, match="requires an explicit"):
             index.create_sql(model=MockItem, schema_editor=schema_editor)
 
     def test_json_field_literal_alias(self) -> None:


### PR DESCRIPTION
## Summary

Two correctness fixes in `paradedb/indexes.py`, both surfaced by a code audit. Each was confirmed by reading the code before changing it.

### 1. Unreachable descriptive `ValueError` for JSON keys (`_build_json_key_expressions`)

The original order was:

```python
tokenizer = config.get("tokenizer")
if not isinstance(tokenizer, Tokenizer):   # catches None too
    raise TypeError("tokenizer must be a Tokenizer")
if tokenizer is None:                      # DEAD: never reached
    raise ValueError("JSON key ... requires an explicit tokenizer ...")
```

Because `isinstance(None, Tokenizer)` is `False`, a JSON key with a **missing** tokenizer always raised the generic `TypeError`, and the helpful `ValueError` (with field name + examples) could never fire.

**Fix:** reorder so the `None` check (descriptive `ValueError`) runs *before* the type check. The `TypeError` now correctly covers the remaining case: a non-`None` value that isn't a `Tokenizer` (e.g. a string).

### 2. Dead `IndexExpression` config fields — removed (not implemented)

`IndexExpression` declared `args`, `named_args`, `filters`, and `stemmer`, but `_build_computed_expression` only ever reads `expression`, `tokenizer`, and `alias`. Any value passed for those four fields was **silently dropped** — never rendered into SQL.

**Decision: remove, don't implement.** Rationale:
- No test, example, or doc passes any of these four fields to `IndexExpression`. The tokenizer-options tests (`stemmer`, `filters`, positional `args`, `named_args`) all configure them on the `Tokenizer` object via factory methods (`Tokenizer.simple(options=...)`, `Tokenizer.ngram(...)`), which is the real, working mechanism. So there is no evidence these fields were intended to render, and inventing render semantics would risk emitting incorrect SQL.
- `alias` is genuinely used (text-vs-JSON error message + `pdb.alias(...)` rendering), so it stays.

Changes:
- Removed the four unused fields from the dataclass.
- Updated the docstring to drop the misleading args and point users at `Tokenizer` factory methods for tokenizer configuration.
- Cleaned the misleading `_build_index_expressions` mix-error message so it only names keys that path actually parses: `'tokenizer' or 'alias'` (it previously listed `args`, `named_args`, `filters`, `stemmer`, none of which that path reads).

### Tests

- Renamed/updated the JSON-key test to assert the now-reachable descriptive `ValueError` when the tokenizer is missing.
- Added a test confirming a wrong-type (non-`None`) tokenizer still raises `TypeError`.
- Grepped all callers/tests/examples/docs: none pass the removed fields, so no other updates were needed.

## Verification

- `python -c "import ast; ast.parse(...)"` — OK
- `ruff check paradedb/indexes.py tests/test_indexing.py` — All checks passed
- `pytest tests/test_indexing.py -k index` — 39 passed (all pure SQL-generation; no live DB)
- `pytest tests/test_indexing.py` — 39 passed

## Caveats

- DB-bound suites were not run here: `tests/test_migrations.py` requires the `django_db` marker (pytest-django + a live ParadeDB/Postgres), and `tests/conftest.py` hard-requires `psycopg`. `test_indexing.py` is entirely SQL-generation and fully exercised.