### PR TITLE
chore: Remove max_term_freq and release 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+## [0.10.0] - 2026-07-14
+
+### Removed
+
+- Removed max_term_freq from MoreLikeThis.
+
 ## [0.9.0] - 2026-06-18
 
 ### Added
@@ -209,6 +215,7 @@ All notable changes to this project will be documented in this file. The format 
 - JSON field key indexing support
 - Full Django ORM integration with `Q` objects and standard filters
 
+[0.10.0]: https://github.com/paradedb/django-paradedb/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/paradedb/django-paradedb/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/paradedb/django-paradedb/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/paradedb/django-paradedb/compare/v0.6.0...v0.7.0

--- a/paradedb/search.py
+++ b/paradedb/search.py
@@ -608,7 +608,6 @@ class MoreLikeThis(Expression):
         min_term_freq: int | None = None,
         max_query_terms: int | None = None,
         min_doc_freq: int | None = None,
-        max_term_freq: int | None = None,
         max_doc_freq: int | None = None,
         min_word_length: int | None = None,
         max_word_length: int | None = None,
@@ -623,7 +622,6 @@ class MoreLikeThis(Expression):
         self.min_term_freq = min_term_freq
         self.max_query_terms = max_query_terms
         self.min_doc_freq = min_doc_freq
-        self.max_term_freq = max_term_freq
         self.max_doc_freq = max_doc_freq
         self.min_word_length = min_word_length
         self.max_word_length = max_word_length
@@ -706,7 +704,6 @@ class MoreLikeThis(Expression):
             "min_term_freq": self.min_term_freq,
             "max_query_terms": self.max_query_terms,
             "min_doc_freq": self.min_doc_freq,
-            "max_term_freq": self.max_term_freq,
             "max_doc_freq": self.max_doc_freq,
             "min_word_length": self.min_word_length,
             "max_word_length": self.max_word_length,
@@ -740,7 +737,6 @@ def _render_more_like_this_call(
             "min_term_frequency": term.min_term_freq,
             "max_query_terms": term.max_query_terms,
             "min_doc_frequency": term.min_doc_freq,
-            "max_term_frequency": term.max_term_freq,
             "max_doc_frequency": term.max_doc_freq,
             "min_word_length": term.min_word_length,
             "max_word_length": term.max_word_length,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-paradedb"
-version = "0.9.0"
+version = "0.10.0"
 description = "Official ParadeDB integration for Django"
 readme = "README.md"
 license = "MIT"

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -337,7 +337,6 @@ class TestMoreLikeThisValidation:
             min_term_freq=2,
             max_query_terms=10,
             min_doc_freq=1,
-            max_term_freq=100,
             max_doc_freq=1000,
             min_word_length=3,
             max_word_length=15,

--- a/uv.lock
+++ b/uv.lock
@@ -197,7 +197,7 @@ wheels = [
 
 [[package]]
 name = "django-paradedb"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This field isn't actually supported by ParadeDB, so it needs to be removed. See https://github.com/paradedb/tantivy/pull/149#issuecomment-4685612822.

## Why

## How

## Tests
