### PR TITLE
feat: support vector index build options (centroid_ratio, training_samples_per_centroid, cluster_replication)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+### Added
+
+- Vector index build options on `ParadeDBIndex`: `centroid_ratio`, `training_samples_per_centroid`, and `cluster_replication` are emitted in the `WITH (...)` clause alongside `key_field`. They are index-wide, apply to every vector field in the index, and are validated against the ranges accepted by pg_search.
+
 ## [0.11.0] - 2026-08-04
 
 ### Added

--- a/paradedb/indexes.py
+++ b/paradedb/indexes.py
@@ -92,6 +92,24 @@ def _expression_requires_tokenizer(expression: Expression) -> bool:
     return False
 
 
+def _validate_int_index_option(name: str, value: Any, *, maximum: int) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"{name} must be an integer.")
+    if not 1 <= value <= maximum:
+        raise ValueError(f"{name} must be between 1 and {maximum}, inclusive.")
+
+
+def _validate_centroid_ratio(value: Any) -> None:
+    if value is None:
+        return
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise TypeError("centroid_ratio must be a number.")
+    if not 0.000001 <= value <= 1.0:
+        raise ValueError("centroid_ratio must be between 0.000001 and 1.0, inclusive.")
+
+
 def _render_native_json_fields_json(json_fields: dict[str, dict[str, Any]]) -> str:
     return json.dumps(json_fields, separators=(",", ":"), sort_keys=True)
 
@@ -171,6 +189,11 @@ class ParadeDBIndex(models.Index):
 
     The index is created with ``USING paradedb``, the index access method
     name in pg_search 0.25.0+.
+
+    ``centroid_ratio``, ``training_samples_per_centroid``, and
+    ``cluster_replication`` are index-wide vector build options emitted in
+    the ``WITH (...)`` clause. They apply to every vector field in the index
+    and are meaningful only when the index contains a vector field.
     """
 
     suffix = "search"
@@ -183,10 +206,25 @@ class ParadeDBIndex(models.Index):
         name: str,
         expressions: list[IndexExpression] | None = None,
         condition: models.Q | None = None,
+        centroid_ratio: float | None = None,
+        training_samples_per_centroid: int | None = None,
+        cluster_replication: int | None = None,
     ) -> None:
+        _validate_centroid_ratio(centroid_ratio)
+        _validate_int_index_option(
+            "training_samples_per_centroid",
+            training_samples_per_centroid,
+            maximum=100000,
+        )
+        _validate_int_index_option(
+            "cluster_replication", cluster_replication, maximum=2147483647
+        )
         self.fields_config = fields
         self.key_field = key_field
         self.index_expressions = list(expressions or [])
+        self.centroid_ratio = centroid_ratio
+        self.training_samples_per_centroid = training_samples_per_centroid
+        self.cluster_replication = cluster_replication
         super().__init__(name=name, fields=list(fields.keys()), condition=condition)
 
     def deconstruct(self) -> tuple[str, Any, dict[str, Any]]:
@@ -196,6 +234,14 @@ class ParadeDBIndex(models.Index):
         kwargs["name"] = self.name
         if self.index_expressions:
             kwargs["expressions"] = self.index_expressions
+        for option in (
+            "centroid_ratio",
+            "training_samples_per_centroid",
+            "cluster_replication",
+        ):
+            value = getattr(self, option)
+            if value is not None:
+                kwargs[option] = value
         return path, args, kwargs
 
     def create_sql(
@@ -217,6 +263,14 @@ class ParadeDBIndex(models.Index):
                 "json_fields="
                 + _quote_term(_render_native_json_fields_json(json_fields))
             )
+        for option in (
+            "centroid_ratio",
+            "training_samples_per_centroid",
+            "cluster_replication",
+        ):
+            value = getattr(self, option)
+            if value is not None:
+                storage_params.append(f"{option}={value}")
 
         create_stmt = "CREATE INDEX"
         if concurrently:

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -948,3 +948,151 @@ class TestVectorIndex:
 
         serialized, _imports = MigrationWriter.serialize(index)
         assert "'metric': 'cosine'" in serialized
+
+
+class TestVectorIndexOptions:
+    """Test vector build options in the WITH clause of ParadeDBIndex."""
+
+    def test_index_with_all_options_emits_with_clause(self) -> None:
+        index = ParadeDBIndex(
+            fields={"id": {}, "embedding": {"metric": "cosine"}},
+            key_field="id",
+            name="mock_items_search_idx",
+            centroid_ratio=0.01,
+            training_samples_per_centroid=32,
+            cluster_replication=1,
+        )
+        sql = str(index.create_sql(model=MockItem, schema_editor=_schema_editor()))
+        assert (
+            sql
+            == 'CREATE INDEX "mock_items_search_idx" ON "mock_items"\nUSING paradedb (\n    "id",\n    "embedding" vector_cosine_ops\n)\nWITH (key_field=\'id\', centroid_ratio=0.01, training_samples_per_centroid=32, cluster_replication=1)'
+        )
+
+    def test_index_with_single_option(self) -> None:
+        index = ParadeDBIndex(
+            fields={"id": {}, "embedding": {"metric": "l2"}},
+            key_field="id",
+            name="mock_items_search_idx",
+            cluster_replication=2,
+        )
+        sql = str(index.create_sql(model=MockItem, schema_editor=_schema_editor()))
+        assert (
+            sql
+            == 'CREATE INDEX "mock_items_search_idx" ON "mock_items"\nUSING paradedb (\n    "id",\n    "embedding" vector_l2_ops\n)\nWITH (key_field=\'id\', cluster_replication=2)'
+        )
+
+    def test_options_allowed_without_vector_field(self) -> None:
+        index = ParadeDBIndex(
+            fields={"id": {}, "description": {}},
+            key_field="id",
+            name="mock_items_search_idx",
+            centroid_ratio=0.5,
+        )
+        sql = str(index.create_sql(model=MockItem, schema_editor=_schema_editor()))
+        assert "centroid_ratio=0.5" in sql
+
+    @pytest.mark.parametrize(
+        "centroid_ratio",
+        [0.0000001, 0.0, 1.5, -0.01],
+    )
+    def test_centroid_ratio_out_of_range_raises(self, centroid_ratio: float) -> None:
+        with pytest.raises(ValueError, match="centroid_ratio must be between"):
+            ParadeDBIndex(
+                fields={"id": {}},
+                key_field="id",
+                name="mock_items_search_idx",
+                centroid_ratio=centroid_ratio,
+            )
+
+    def test_centroid_ratio_invalid_type_raises(self) -> None:
+        with pytest.raises(TypeError, match="centroid_ratio must be a number"):
+            ParadeDBIndex(
+                fields={"id": {}},
+                key_field="id",
+                name="mock_items_search_idx",
+                centroid_ratio="0.01",  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.parametrize("training_samples_per_centroid", [0, 100001, -1])
+    def test_training_samples_per_centroid_out_of_range_raises(
+        self, training_samples_per_centroid: int
+    ) -> None:
+        with pytest.raises(
+            ValueError, match="training_samples_per_centroid must be between"
+        ):
+            ParadeDBIndex(
+                fields={"id": {}},
+                key_field="id",
+                name="mock_items_search_idx",
+                training_samples_per_centroid=training_samples_per_centroid,
+            )
+
+    @pytest.mark.parametrize("training_samples_per_centroid", [32.5, True, "32"])
+    def test_training_samples_per_centroid_invalid_type_raises(
+        self, training_samples_per_centroid: object
+    ) -> None:
+        with pytest.raises(
+            TypeError, match="training_samples_per_centroid must be an integer"
+        ):
+            ParadeDBIndex(
+                fields={"id": {}},
+                key_field="id",
+                name="mock_items_search_idx",
+                training_samples_per_centroid=training_samples_per_centroid,  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.parametrize("cluster_replication", [0, 2147483648])
+    def test_cluster_replication_out_of_range_raises(
+        self, cluster_replication: int
+    ) -> None:
+        with pytest.raises(ValueError, match="cluster_replication must be between"):
+            ParadeDBIndex(
+                fields={"id": {}},
+                key_field="id",
+                name="mock_items_search_idx",
+                cluster_replication=cluster_replication,
+            )
+
+    def test_options_deconstruct_and_serialize(self) -> None:
+        index = ParadeDBIndex(
+            fields={"id": {}, "embedding": {"metric": "cosine"}},
+            key_field="id",
+            name="mock_items_search_idx",
+            centroid_ratio=0.01,
+            training_samples_per_centroid=32,
+            cluster_replication=1,
+        )
+        _path, _args, kwargs = index.deconstruct()
+        assert kwargs["centroid_ratio"] == 0.01
+        assert kwargs["training_samples_per_centroid"] == 32
+        assert kwargs["cluster_replication"] == 1
+
+        serialized, _imports = MigrationWriter.serialize(index)
+        assert "centroid_ratio=0.01" in serialized
+        assert "training_samples_per_centroid=32" in serialized
+        assert "cluster_replication=1" in serialized
+
+    def test_unset_options_omitted_from_deconstruct(self) -> None:
+        index = ParadeDBIndex(
+            fields={"id": {}},
+            key_field="id",
+            name="mock_items_search_idx",
+        )
+        _path, _args, kwargs = index.deconstruct()
+        assert "centroid_ratio" not in kwargs
+        assert "training_samples_per_centroid" not in kwargs
+        assert "cluster_replication" not in kwargs
+
+    def test_indexes_with_equal_options_compare_equal(self) -> None:
+        def build(cluster_replication: int) -> ParadeDBIndex:
+            return ParadeDBIndex(
+                fields={"id": {}, "embedding": {"metric": "cosine"}},
+                key_field="id",
+                name="mock_items_search_idx",
+                centroid_ratio=0.01,
+                training_samples_per_centroid=32,
+                cluster_replication=cluster_replication,
+            )
+
+        assert build(1) == build(1)
+        assert build(1) != build(2)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -150,6 +150,9 @@ def test_apply_and_unapply_create_model_migration(
                     },
                     key_field="id",
                     name=index_name,
+                    centroid_ratio=0.01,
+                    training_samples_per_centroid=32,
+                    cluster_replication=1,
                 )
             ],
         },
@@ -186,6 +189,9 @@ def test_apply_and_unapply_create_model_migration(
         )
         assert f"title::pdb.{tokenizer_name}" in normalized_index_def, index_def
         assert "vector_cosine_ops" in index_def, index_def
+        assert "centroid_ratio" in index_def, index_def
+        assert "training_samples_per_centroid" in index_def, index_def
+        assert "cluster_replication" in index_def, index_def
         assert {"id", "title", "metadata", "embedding"}.issubset(column_names)
 
         # Insert test data in a separate transaction (simulates real usage)


### PR DESCRIPTION
Exposes pg_search 0.25.0+ vector index build options (`centroid_ratio`, `training_samples_per_centroid`, `cluster_replication`) on `ParadeDBIndex`, so the `WITH (...)` clause can be configured without raw SQL. The options are index-wide, validated against the server-accepted ranges, and round-trip through `deconstruct()`/migrations.

```python
ParadeDBIndex(
    fields={"id": {}, "embedding": {"metric": "cosine"}},
    key_field="id",
    name="search_idx",
    centroid_ratio=0.01,
    training_samples_per_centroid=32,
    cluster_replication=1,
)
```