### PR TITLE
fix(examples): use ParadeDB vector search in hybrid and RAG examples

### DIFF
--- a/examples/hybrid_rrf/hybrid_rrf.py
+++ b/examples/hybrid_rrf/hybrid_rrf.py
@@ -18,7 +18,7 @@ from django.db.models.functions import Cast, RowNumber
 from django_cte import CTE, with_cte
 
 from paradedb.functions import Score
-from paradedb.search import MatchAll, ParadeDB
+from paradedb.search import All, MatchAll, ParadeDB
 from paradedb.vector import CosineDistance
 
 
@@ -64,9 +64,12 @@ def hybrid_search(
     )
     fulltext_cte = CTE(fulltext_qs, name="fulltext")
 
-    # CTE 2: Vector similarity search with ROW_NUMBER rank
+    # CTE 2: Vector similarity search with ROW_NUMBER rank.
+    # The ParadeDB(All()) predicate is required: without a @@@ predicate the
+    # index cannot serve the query and Postgres falls back to a sequential scan.
     semantic_qs = (
-        MockItem.objects.annotate(distance=CosineDistance("embedding", query_embedding))
+        MockItem.objects.filter(id=ParadeDB(All()))
+        .annotate(distance=CosineDistance("embedding", query_embedding))
         .annotate(rank=Window(expression=RowNumber(), order_by=F("distance").asc()))
         .order_by("distance")
         .values("id", "rank")[:top_k]

--- a/examples/hybrid_rrf/hybrid_rrf.py
+++ b/examples/hybrid_rrf/hybrid_rrf.py
@@ -65,8 +65,6 @@ def hybrid_search(
     fulltext_cte = CTE(fulltext_qs, name="fulltext")
 
     # CTE 2: Vector similarity search with ROW_NUMBER rank.
-    # The ParadeDB(All()) predicate is required: without a @@@ predicate the
-    # index cannot serve the query and Postgres falls back to a sequential scan.
     semantic_qs = (
         MockItem.objects.filter(id=ParadeDB(All()))
         .annotate(distance=CosineDistance("embedding", query_embedding))

--- a/examples/rag/rag.py
+++ b/examples/rag/rag.py
@@ -32,10 +32,6 @@ def retrieve(
     query: str, query_embedding: list[float], top_k: int = 5
 ) -> list[MockItem]:
     """Retrieve relevant products with hybrid retrieval.
-
-    The ``@@@`` predicate narrows to keyword matches and activates the ParadeDB
-    index scan; ordering by ``CosineDistance`` then ranks those matches
-    semantically. One index serves both halves.
     """
     qs = (
         MockItem.objects.filter(description=ParadeDB(Parse(query, lenient=True)))

--- a/examples/rag/rag.py
+++ b/examples/rag/rag.py
@@ -9,23 +9,38 @@ import httpx
 from dotenv import load_dotenv
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from common import MockItem, setup_mock_items
+from common import QUERY_EMBEDDINGS, MockItem, setup_mock_items
 
-from paradedb.functions import Score
 from paradedb.search import ParadeDB, Parse
+from paradedb.vector import CosineDistance
 
 load_dotenv()
 
 OPENROUTER_API_KEY = os.environ.get("OPENROUTER_API_KEY")
 MODEL = os.environ.get("RAG_MODEL", "anthropic/claude-3-haiku")
 
+# Maps each demo question to a pre-computed query embedding in common.py. A real
+# application would embed the question with the same model used for the column.
+QUERY_EMBEDDING_SEEDS: dict[str, str] = {
+    "What running shoes do you have?": "running shoes",
+    "I need comfortable shoes for everyday use": "footwear for exercise",
+    "Do you have any wireless audio products?": "wireless earbuds",
+}
 
-def retrieve(query: str, top_k: int = 5) -> list[MockItem]:
-    """Retrieve relevant products using BM25 search."""
+
+def retrieve(
+    query: str, query_embedding: list[float], top_k: int = 5
+) -> list[MockItem]:
+    """Retrieve relevant products with hybrid retrieval.
+
+    The ``@@@`` predicate narrows to keyword matches and activates the ParadeDB
+    index scan; ordering by ``CosineDistance`` then ranks those matches
+    semantically. One index serves both halves.
+    """
     qs = (
         MockItem.objects.filter(description=ParadeDB(Parse(query, lenient=True)))
-        .annotate(score=Score())
-        .order_by("-score")[:top_k]
+        .annotate(distance=CosineDistance("embedding", query_embedding))
+        .order_by("distance")[:top_k]
     )
     return list(qs)
 
@@ -87,10 +102,10 @@ def rag(query: str) -> None:
     print("=" * 60)
 
     # Retrieve
-    items = retrieve(query)
+    items = retrieve(query, QUERY_EMBEDDINGS[QUERY_EMBEDDING_SEEDS[query]])
     print(f"\nRetrieved {len(items)} products:")
     for item in items:
-        print(f"  • {item.description} (score: {item.score:.2f})")
+        print(f"  • {item.description} (distance: {item.distance:.4f})")
 
     # Generate
     context = format_context(items)


### PR DESCRIPTION
The recent vector search work put the vector column inside the ParadeDB index in every ORM, but some examples still query it the old way. This fixes the ones in this repo. Companion PRs are open in the other affected repos; sqlalchemy needed no change.

## The problem

For the ParadeDB index to serve a vector query, three things are required together: a `@@@` predicate, a distance operator matching the index opclass metric, and a `LIMIT`. Drop the `@@@` predicate and the query still returns correct rows, so nothing fails loudly — it just silently stops using the index and becomes a sequential scan plus a sort. That is exactly the vanilla pgvector behavior these examples are meant to show you how to avoid.

## Verification

Measured with `EXPLAIN` against ParadeDB 0.25.0. Before:

```text
Limit
  ->  Sort
        Sort Key: ((embedding <=> '[...]'::vector))
        ->  Seq Scan on mock_items
```

After:

```text
Limit
  ->  Custom Scan (ParadeDB Base Scan) on mock_items
        Table: mock_items
        Index: search_idx
        Exec Method: TopKScanExecState
        Scores: false
           TopK Order By: embedding <=> vector asc
           TopK Limit: 20
        Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
```

Every changed example was run end to end against a live ParadeDB container and produces sensible rankings.

## What changed here

**`examples/hybrid_rrf/hybrid_rrf.py`** — the semantic CTE had no `@@@` predicate. Adds `ParadeDB(All())`, which `vector_search.py` already documents as mandatory in its own module docstring.

**`examples/rag/rag.py`** — retrieval was BM25-only, with no vector step at all (`"""Retrieve relevant products using BM25 search."""`). It now uses the same hybrid shape as the rails and drizzle RAG examples: `Parse` narrows to keyword matches and activates the index scan, `CosineDistance` orders those matches semantically. Demo questions map to the pre-computed vectors already in `common.py`.

Full test suite passes (322 tests). Note that `scripts/run_examples.sh` does not run the RAG example, which is why CI never caught this; I left that alone here since adding it would make CI depend on `OPENROUTER_API_KEY`.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4
