### PR TITLE
chore: collapse the RAG retrieve docstring to one line

### DIFF
--- a/examples/rag/rag.py
+++ b/examples/rag/rag.py
@@ -31,8 +31,7 @@ QUERY_EMBEDDING_SEEDS: dict[str, str] = {
 def retrieve(
     query: str, query_embedding: list[float], top_k: int = 5
 ) -> list[MockItem]:
-    """Retrieve relevant products with hybrid retrieval.
-    """
+    """Retrieve relevant products with hybrid retrieval."""
     qs = (
         MockItem.objects.filter(description=ParadeDB(Parse(query, lenient=True)))
         .annotate(distance=CosineDistance("embedding", query_embedding))


### PR DESCRIPTION
`main` is currently red: the **Ruff format check** in the Lint job fails on `examples/rag/rag.py`.

## Cause

The explanatory body of `retrieve()`s docstring was removed between the push to #154 and its merge, which left a single line of text still wrapped in a multi-line docstring:

```python
"""Retrieve relevant products with hybrid retrieval.
"""
```

Ruff collapses that to one line. Nothing else on main is affected — 40 of 41 files are already formatted.

## Verification

- `ruff format --check .` passes
- `ruff check .` passes
- Full test suite passes (322 tests)

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4