### PR TITLE
test: add a packaging smoke test to every ORM integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Check API stub sync
         run: uv run --no-sync python scripts/check_api_stub_sync.py
 
-      - name: Wheel install smoke test
-        run: bash scripts/smoke_wheel_install.sh
+      - name: Package install smoke test
+        run: bash scripts/smoke_package_install.sh
 
   matrix-tests:
     name: Python ${{ matrix.python-version }} / Django ${{ matrix.django-version }} / PG ${{ matrix.postgres-version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ Run these before opening a PR if your change touches SQL wrappers, API constants
 ```bash
 uv run python scripts/check_api_coverage.py
 uv run python scripts/check_api_stub_sync.py
-bash scripts/smoke_wheel_install.sh
+bash scripts/smoke_package_install.sh
 ```
 
 ### Pull Request Workflow

--- a/scripts/smoke_package_install.sh
+++ b/scripts/smoke_package_install.sh
@@ -62,5 +62,9 @@ sql = str(
     SmokeModel.objects.filter(description=ParadeDB(MatchAll("shoes"))).query
 )
 if "&&&" not in sql:
-    raise SystemExit("Wheel smoke test failed: expected ParadeDB SQL operator.")
+    raise SystemExit("Package smoke test failed: expected ParadeDB SQL operator.")
 PY
+
+WHEEL_NAME="$(basename "$(find "${DIST_DIR}" -name 'django_paradedb-*.whl' | head -1)")"
+VERSION="${WHEEL_NAME#django_paradedb-}"; VERSION="${VERSION%%-*}"
+echo "✅ Package smoke install passed for django-paradedb ${VERSION}"


### PR DESCRIPTION
drizzle and efcore had **no packaging check at all**. django and sqlalchemy had `smoke_wheel_install.sh`, rails had `smoke_gem_install.sh`; all three are now `scripts/smoke_package_install.sh`, so the file has the same name everywhere.

## Why this matters more than it sounds

A packaging smoke test catches a class of bug the test suite structurally **cannot**: the tests import from the source tree, while consumers get only what the published artifact actually contains.

Concretely, django and sqlalchemy force-include `api.json5` into the wheel and load it at import time to define every API constant. A regression there would ship a package that fails on import for every user, while CI stayed entirely green.

## What each script does

Each builds the real artifact, installs it into a throwaway project, and exercises the public API **from the installed copy**:

| Repo | Approach |
|---|---|
| django, sqlalchemy | build the wheel → install into a fresh venv → compile a query, assert `&&&` |
| drizzle | `pnpm build` → `npm pack` → assert `dist/index.js` and `dist/index.d.ts` are in the tarball → install into a scratch project → assert `PgDialect` renders `&&&` |
| rails | `gem build` → install into an isolated `GEM_HOME` → assert the Arel node is a ParadeDB match infix operation |
| efcore | `dotnet pack` → restore from a local feed into a scratch console project → assert `MatchAll`, `Score`, `Parse` are public statics on the packed assembly |

All five run in CI as **Package install smoke test**, and are documented under *API and Packaging Consistency Checks* — drizzle and efcore previously documented no packaging step.

## Verification

Every script exits 0 as-is:

```
django      ✅ Package smoke install passed for django-paradedb 0.12.0
sqlalchemy  ✅ Package smoke install passed for sqlalchemy-paradedb 0.10.0
drizzle     ✅ Package smoke install passed for @paradedb/drizzle-paradedb@0.4.0
rails       ✅ Package smoke install passed for rails-paradedb 0.11.0
efcore      ✅ Package smoke install passed for ParadeDB.EntityFrameworkCore 1.0.0
```

And they were **negative-tested**, so they aren't inert:

- breaking drizzle's `files` so `dist` isn't published → exit 1, `❌ package/dist/index.d.ts missing from the packed tarball`
- asking efcore for a method that doesn't exist → exit 1, `Expected public static ParadeDbFunctionsExtensions.ThisMethodDoesNotExist in the packed assembly`

rails ran in a Ruby 3.4 container and efcore in a .NET 10 container, since this machine has neither toolchain. shellcheck, beautysh, prettier, markdownlint and codespell all pass.

https://claude.ai/code/session_01UvsxqSXgKrHhKhHAH1BcV4