### PR TITLE
chore: add aggregations package keyword

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ keywords = [
     "vector search",
     "faceted search",
     "facets",
+    "aggregations",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",


### PR DESCRIPTION
Adds the missing 'aggregations' keyword to the PyPI package metadata so it reflects the integration's supported feature set. No pgvector keyword or description change is included.

Validation:
- parsed pyproject.toml with Python tomllib
- git diff --check