### PR TITLE
chore: modernize pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: no-commit-to-branch
         args: ["--branch", "main", "--branch", "dev"]
@@ -30,20 +30,20 @@ repos:
       - id: fix-byte-order-marker
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+    rev: v0.49.1
     hooks:
       - id: markdownlint
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.3
     hooks:
       - id: codespell
         args: ["--config", ".codespellrc", "--check-filenames"]
         exclude: ^uv\.lock$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.16.4
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
 


### PR DESCRIPTION
Updates pre-commit-hooks, markdownlint, codespell, and Ruff; switches Ruff from the legacy alias to ruff-check. Existing mypy and pytest hooks are preserved.\n\nValidation: configuration, markdownlint, codespell, Ruff check, and Ruff format pass.