### PR TITLE
chore: run Python formatters before validators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,13 @@ repos:
       - id: destroyed-symlinks
       - id: fix-byte-order-marker
 
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.4
+    hooks:
+      - id: ruff-check
+        args: [--fix]
+      - id: ruff-format
+
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.12
     hooks:
@@ -46,13 +53,6 @@ repos:
       - id: codespell
         args: ["--config", ".codespellrc", "--check-filenames"]
         exclude: ^uv\.lock$
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.4
-    hooks:
-      - id: ruff-check
-        args: [--fix]
-      - id: ruff-format
-
   - repo: local
     hooks:
       - id: mypy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,7 @@ repos:
       - id: codespell
         args: ["--config", ".codespellrc", "--check-filenames"]
         exclude: ^uv\.lock$
+
   - repo: local
     hooks:
       - id: mypy


### PR DESCRIPTION
Normalizes pre-commit ordering so Ruff’s fixing and formatting hooks run before actionlint, markdownlint, codespell, mypy, and tests.

No hook versions or behavior change. Ruff checks and formatting pass.