### PR TITLE
docs: update documentation URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@
 
 <h3 align="center">
   <a href="https://paradedb.com">Website</a> &bull;
-  <a href="https://docs.paradedb.com">Docs</a> &bull;
+  <a href="https://paradedb.com/docs">Docs</a> &bull;
   <a href="https://paradedb.com/slack/">Community</a> &bull;
   <a href="https://paradedb.com/blog/">Blog</a> &bull;
-  <a href="https://docs.paradedb.com/changelog/">Changelog</a>
+  <a href="https://paradedb.com/docs/changelog/">Changelog</a>
 </h3>
 
 <p align="center">
@@ -36,7 +36,7 @@
 
 ## ParadeDB for Django
 
-The official [Django](https://www.djangoproject.com/) integration for [ParadeDB](https://paradedb.com) (powered by the [`pg_search`](https://github.com/paradedb/paradedb) Postgres extension), including first-class support for managing ParadeDB indexes and running queries using the full ParadeDB API. The integration covers both [full-text search](https://docs.paradedb.com/documentation/full-text/overview) and [vector search](https://docs.paradedb.com/documentation/vector/overview) over pgvector `vector` types. Follow the [getting started guide](https://docs.paradedb.com/documentation/getting-started/environment#django) to begin.
+The official [Django](https://www.djangoproject.com/) integration for [ParadeDB](https://paradedb.com) (powered by the [`pg_search`](https://github.com/paradedb/paradedb) Postgres extension), including first-class support for managing ParadeDB indexes and running queries using the full ParadeDB API. The integration covers both [full-text search](https://paradedb.com/docs/documentation/full-text/overview) and [vector search](https://paradedb.com/docs/documentation/vector/overview) over pgvector `vector` types. Follow the [getting started guide](https://paradedb.com/docs/documentation/getting-started/environment#django) to begin.
 
 ## Requirements & Compatibility
 

--- a/paradedb/functions.py
+++ b/paradedb/functions.py
@@ -150,7 +150,7 @@ class SnippetPositions(Func):
     Wraps ``pdb.snippet_positions(column)`` which returns start/end byte
     offset pairs for each matching term.
 
-    See: https://docs.paradedb.com/documentation/full-text/highlight#byte-offsets
+    See: https://paradedb.com/docs/documentation/full-text/highlight#byte-offsets
     """
 
     function = FN_SNIPPET_POSITIONS

--- a/paradedb/search.py
+++ b/paradedb/search.py
@@ -295,7 +295,7 @@ class Phrase:
     Note: The slop parameter controls the maximum number of intervening unmatched
     tokens allowed between words in a phrase. Higher values increase query flexibility
     but may impact performance. Commonly used values are 0-10.
-    See: https://docs.paradedb.com/documentation/full-text/phrase
+    See: https://paradedb.com/docs/documentation/full-text/phrase
     """
 
     terms: tuple[SearchValue, ...]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ examples = [
 ]
 [project.urls]
 Homepage = "https://paradedb.com"
-Documentation = "https://docs.paradedb.com"
+Documentation = "https://paradedb.com/docs"
 Repository = "https://github.com/paradedb/django-paradedb"
 Issues = "https://github.com/paradedb/django-paradedb/issues"
 Changelog = "https://github.com/paradedb/django-paradedb/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary

- update ParadeDB documentation links from docs.paradedb.com to paradedb.com/docs
- preserve every existing documentation path and anchor

## Verification

- confirmed representative replacement URLs resolve successfully
- git diff --check
- verified no obsolete documentation URLs remain, excluding the intentional legacy-host redirect rules in the website repository